### PR TITLE
Add Entry for OPAL Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 * [JArchitect](https://www.jarchitect.com) :copyright: - Measure, query and visualize your code and avoid unexpected issues, technical debt and complexity.
 * [JBMC](http://www.cprover.org/jbmc/) - bounded model-checker for Java (bytecode), verifies user-defined assertions, standard assertions, several coverage metric analyses
 * [NullAway](https://github.com/uber/NullAway) - Type-based null-pointer checker with low build-time overhead; an [Error Prone](http://errorprone.info/) plugin
+* [OPAL](https://github.com/stg-tud/opal) - OPAL is an extensible library for analyzing and engineering Java bytecode
 * [OWASP Dependency Check](https://www.owasp.org/index.php/OWASP_Dependency_Check) - Checks dependencies for known, publicly disclosed, vulnerabilities.
 * [qulice](https://www.qulice.com/) - combines a few (pre-configured) static analysis tools (checkstyle, PMD, Findbugs, ...).
 * [Soot](https://sable.github.io/soot/) - A framework for analyzing and transforming Java and Android applications.


### PR DESCRIPTION
Added an entry for the OPAL framework. OPAL is written in Scala and allows for analyzing and modifying Java byte code.