### PR TITLE
[WIP] Parsing star count badge from linters with a Github source field

### DIFF
--- a/data/render/src/types.rs
+++ b/data/render/src/types.rs
@@ -57,3 +57,23 @@ pub struct Catalog {
     pub others: EntryMap,
     pub multi: Vec<Entry>,
 }
+
+/// any filters defined in `mod filters` are accessible in templates
+mod filters {
+    // eventually, if other open-source sites (e.g. gitlab) support something like stars, those
+    // could also be formatted in this filter
+    pub fn format_badge(s: &str) -> ::askama::Result<String> {
+        let components: Vec<&str> = s.split("/").collect();
+        if components.contains(&"github.com") && components.len() == 5 {
+            // valid github source must have 5 elements - anything longer and they are probably a
+            // reference to a path inside a repo, rather than a repo itself.
+            Ok(format!("![stars]({}{}) ",
+                // shields.io can't have a trailing '/' before parameters begin
+                s.replace("github.com", "img.shields.io/github/stars").trim_end_matches("/"),
+                "?style=flat-square&color=ccc",
+            ))
+        } else {
+            Ok("".to_string())
+        }
+    }
+}

--- a/data/render/templates/README.md
+++ b/data/render/templates/README.md
@@ -45,7 +45,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 <h2 id="{{ language.tag }}">{{ language.name }}</h2>
 
 {% for linter in linters -%}
-- [{{linter.name }}]({{linter.homepage }}){% if linter.deprecated.is_some() %} :warning:{% endif %}{% if linter.proprietary.is_some() %} :copyright:{% endif %} - {{ linter.description }}
+- {% if linter.source.is_some() %}{{ linter.source.as_ref().unwrap()|format_badge }}{%endif%}[{{linter.name }}]({{linter.homepage }}){% if linter.deprecated.is_some() %} :warning:{% endif %}{% if linter.proprietary.is_some() %} :copyright:{% endif %} - {{ linter.description }}
 {% endfor %}
 
 {%- endfor %}


### PR DESCRIPTION
<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- New tools have to be added to `data/tools.yml` (NOT directly in the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->

#327 - initial issue
#375 - old PR (before origin's code refactoring) and discussion

This PR is dependent on the work in #381 . It could be merged directly onto your `additional-fields` branch, or it could be merged into `master` separately.

@mre this is initial work towards parsing the relevant github info from an `linter.source` and using it to generate a github star count badge. We use [askama filters](https://docs.rs/askama/0.9.0/askama/#filters) (found the documentation a bit sparse, but I used the [tests](https://github.com/djc/askama/blob/master/testing/tests/filters.rs#L39) to figure out usage) to parse `linter.source` strings into shields.io badges displaying Github star counts (if the source is a github repository).