### PR TITLE
Remove "deprecated" for jshint

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 - ![stars](https://img.shields.io/github/stars/jquery/esprima?style=flat-square&color=ccc) [Esprima](https://esprima.org/) - ECMAScript parsing infrastructure for multipurpose analysis
 - ![stars](https://img.shields.io/github/stars/facebook/flow?style=flat-square&color=ccc) [flow](https://flow.org/) - A static type checker for JavaScript.
 - ![stars](https://img.shields.io/github/stars/JSMonk/hegel?style=flat-square&color=ccc) [hegel](https://hegel.js.org/) - A static type checker for JavaScript with a bias on type inference and strong type systems.
-- ![stars](https://img.shields.io/github/stars/jshint/jshint?style=flat-square&color=ccc) [jshint](https://jshint.com/about/) :warning: - detect errors and potential problems in JavaScript code and enforce your team's coding conventions
+- ![stars](https://img.shields.io/github/stars/jshint/jshint?style=flat-square&color=ccc) [jshint](https://jshint.com/about/) [:information_source:](https://github.com/analysis-tools-dev/static-analysis/issues/223) - detect errors and potential problems in JavaScript code and enforce your team's coding conventions
 - ![stars](https://img.shields.io/github/stars/douglascrockford/JSLint?style=flat-square&color=ccc) [JSLint](https://github.com/douglascrockford/JSLint) :warning: - The JavaScript Code Quality Tool
 - ![stars](https://img.shields.io/github/stars/dpnishant/jsprime?style=flat-square&color=ccc) [JSPrime](http://dpnishant.github.io/jsprime/) - static security analysis tool
 - ![stars](https://img.shields.io/github/stars/es-analysis/plato?style=flat-square&color=ccc) [plato](https://github.com/es-analysis/plato) - Visualize JavaScript source complexity

--- a/data/render/src/types.rs
+++ b/data/render/src/types.rs
@@ -29,6 +29,7 @@ pub struct Entry {
     pub name: String,
     pub homepage: String,
     pub source: Option<String>,
+    pub discussion: Option<String>,
     pub description: String,
     pub tags: EntryTags,
     pub proprietary: Option<bool>,

--- a/data/render/templates/README.md
+++ b/data/render/templates/README.md
@@ -47,7 +47,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 <h2 id="{{ language.tag }}">{{ language.name }}</h2>
 
 {% for linter in linters -%}
-- {% if linter.source.is_some() %}{{ linter.source.as_ref().unwrap()|format_badge }}{%endif%}[{{linter.name }}]({{linter.homepage }}){% if linter.deprecated.is_some() %} :warning:{% endif %}{% if linter.proprietary.is_some() %} :copyright:{% endif %} - {{ linter.description }}
+- {% if linter.source.is_some() %}{{ linter.source.as_ref().unwrap()|format_badge }}{%endif%}[{{linter.name }}]({{linter.homepage }}){% if linter.discussion.is_some() %} [:information_source:]({{linter.discussion.as_ref().unwrap()}}){% endif %}{% if linter.deprecated.is_some() %} :warning:{% endif %}{% if linter.proprietary.is_some() %} :copyright:{% endif %} - {{ linter.description }}
 {% endfor %}
 
 {%- endfor %}

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -1558,6 +1558,7 @@
 - name: jshint
   homepage: "https://jshint.com/about/"
   source: "https://github.com/jshint/jshint"
+  discussion: "https://github.com/analysis-tools-dev/static-analysis/issues/223"
   description: "detect errors and potential problems in JavaScript code and enforce your team's coding conventions"
   tags:
     - javascript

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -1561,7 +1561,6 @@
   description: "detect errors and potential problems in JavaScript code and enforce your team's coding conventions"
   tags:
     - javascript
-  deprecated: true
 - name: JSLint
   homepage: "https://github.com/douglascrockford/JSLint"
   source: "https://github.com/douglascrockford/JSLint"


### PR DESCRIPTION
I found the latest commit of this repo was about a month ago, so I guess that should be considerd as still maintaining? 

