### PR TITLE
Fix issue for not properly display star badge

### DIFF
--- a/data/render/src/types.rs
+++ b/data/render/src/types.rs
@@ -62,7 +62,10 @@ pub struct Catalog {
 mod filters {
     // eventually, if other open-source sites (e.g. gitlab) support something like stars, those
     // could also be formatted in this filter
-    pub fn format_badge(s: &str) -> ::askama::Result<String> {
+    pub fn format_badge(mut s: &str) -> ::askama::Result<String> {
+        if s.chars().last().unwrap() == '/' {
+            s = s.trim_end_matches('/');
+        }
         let components: Vec<&str> = s.split("/").collect();
         if components.contains(&"github.com") && components.len() == 5 {
             // valid github source must have 5 elements - anything longer and they are probably a

--- a/data/render/templates/README.md
+++ b/data/render/templates/README.md
@@ -55,7 +55,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 # Multiple languages
 
 {% for linter in multi -%}
-- [{{linter.name }}]({{linter.homepage }}){% if linter.deprecated.is_some() %} :warning:{% endif %}{% if linter.proprietary.is_some() %} :copyright:{% endif %} - {{ linter.description }} 
+- {% if linter.source.is_some() %}{{ linter.source.as_ref().unwrap()|format_badge }}{%endif%}[{{linter.name }}]({{linter.homepage }}){% if linter.deprecated.is_some() %} :warning:{% endif %}{% if linter.proprietary.is_some() %} :copyright:{% endif %} - {{ linter.description }} 
 {% endfor %}
 
 # Other
@@ -65,7 +65,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 <h2 id="{{ tag.tag }}">{{ tag.name }}</h2>
 
 {% for other in others -%}
-- [{{ other.name }}]({{ other.homepage }}){% if other.deprecated.is_some() %} :warning:{% endif %}{% if other.proprietary.is_some() %} :copyright:{% endif %} - {{ other.description }}
+- {% if other.source.is_some() %}{{ other.source.as_ref().unwrap()|format_badge }}{%endif%}[{{ other.name }}]({{ other.homepage }}){% if other.deprecated.is_some() %} :warning:{% endif %}{% if other.proprietary.is_some() %} :copyright:{% endif %} - {{ other.description }}
 {% endfor %}
 
 {%- endfor %}


### PR DESCRIPTION
Hi, 
I found that star badge of some github repo was not properly displayed, and the root cause is that the URL contains trailing slash
