### PR TITLE
Modify URL to previous commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,7 +825,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 # More collections
 
 - [go-tools](https://github.com/dominikh/go-tools) - A collection of tools and libraries for working with Go code, including linters and static analysis
-- [linters](https://github.com/mcandre/linters) - An introduction to static code analysis
+- [linters](https://github.com/mcandre/linters/tree/b044f0628c4a96dfea869cf61e0e96cf4c49cf6b) - An introduction to static code analysis
 - [php-static-analysis-tools](https://github.com/exakat/php-static-analysis-tools) -  A reviewed list of useful PHP static analysis tools
 - [Tools for C/C++](https://www.peerlyst.com/posts/a-list-of-static-analysis-tools-for-c-c-peerlyst?utm_source=twitter&utm_medium=social&utm_content=peerlyst_post&utm_campaign=peerlyst_resources) - A list of static analysis tools for C/C++
 - [Wikipedia](http://en.wikipedia.org/wiki/List_of_tools_for_static_code_analysis) -  A list of tools for static code analysis.

--- a/data/render/templates/README.md
+++ b/data/render/templates/README.md
@@ -73,7 +73,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 # More collections
 
 - [go-tools](https://github.com/dominikh/go-tools) - A collection of tools and libraries for working with Go code, including linters and static analysis
-- [linters](https://github.com/mcandre/linters) - An introduction to static code analysis
+- [linters](https://github.com/mcandre/linters/tree/b044f0628c4a96dfea869cf61e0e96cf4c49cf6b) - An introduction to static code analysis
 - [php-static-analysis-tools](https://github.com/exakat/php-static-analysis-tools) -  A reviewed list of useful PHP static analysis tools
 - [Tools for C/C++](https://www.peerlyst.com/posts/a-list-of-static-analysis-tools-for-c-c-peerlyst?utm_source=twitter&utm_medium=social&utm_content=peerlyst_post&utm_campaign=peerlyst_resources) - A list of static analysis tools for C/C++
 - [Wikipedia](http://en.wikipedia.org/wiki/List_of_tools_for_static_code_analysis) -  A list of tools for static code analysis.


### PR DESCRIPTION
I found that the ```README.md``` of this repo contains only one line about COVID-19, same thing happened on some other repos from the same author, so I think maybe we can use the URL of previous commit temporarily?