### PR TITLE
Remove duplicate entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 - ![stars](https://img.shields.io/github/stars/mibk/dupl?style=flat-square&color=ccc) [dupl](https://github.com/mibk/dupl) - Reports potentially duplicated code.
 - ![stars](https://img.shields.io/github/stars/kisielk/errcheck?style=flat-square&color=ccc) [errcheck](https://github.com/kisielk/errcheck) - Check that error return values are used.
 - ![stars](https://img.shields.io/github/stars/lafolle/flen?style=flat-square&color=ccc) [flen](https://github.com/lafolle/flen) - Get info on length of functions in a Go package.
-- ![stars](https://img.shields.io/github/stars/securego/gosec?style=flat-square&color=ccc) [gas](https://securego.io/) - Inspects source code for security problems by scanning the Go AST.
 - [go tool vet --shadow](https://golang.org/cmd/vet/#hdr-Shadowed_variables) - Reports variables that may have been unintentionally shadowed.
 - [go vet](https://golang.org/cmd/vet/) - Examines Go source code and reports suspicious.
 - ![stars](https://img.shields.io/github/stars/Quasilyte/go-consistent?style=flat-square&color=ccc) [go-consistent](https://github.com/Quasilyte/go-consistent) - Analyzer that helps you to make your Go programs more consistent.

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -1177,12 +1177,6 @@
   description: "Lint tool for F#"
   tags:
     - fsharp
-- name: gas
-  homepage: "https://securego.io/"
-  source: "https://github.com/securego/gosec"
-  description: Inspects source code for security problems by scanning the Go AST.
-  tags:
-    - go
 - name: gawk --lint
   homepage: "https://www.gnu.org/software/gawk/manual/html_node/Options.html"
   source: "https://www.gnu.org/software/gawk/manual/html_node/Options.html"


### PR DESCRIPTION
There is another entry called ```gosec (gas)```, which is same as ```gas```