### PR TITLE
Add Stan static analysis tool

### DIFF
--- a/data/tools.yml
+++ b/data/tools.yml
@@ -3382,7 +3382,7 @@
     - javascript
   deprecated: true
 - name: Stan
-  homepage: "https://github.com/kowainik/stan"
+  homepage: "https://kowainik.github.io/projects/stan"
   source: "https://github.com/kowainik/stan"
   description: Stan is a command-line tool for analysing Haskell projects and outputting discovered vulnerabilities in a helpful way with possible solutions for detected problems.
   tags:

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -3381,3 +3381,11 @@
   tags:
     - javascript
   deprecated: true
+- name: Stan
+  homepage: "https://github.com/kowainik/stan"
+  source: "https://github.com/kowainik/stan"
+  description: Stan is a command-line tool for analysing Haskell projects and outputting discovered vulnerabilities in a helpful way with possible solutions for detected problems.
+  tags:
+    - haskell
+    - configfile
+    - json


### PR DESCRIPTION
Stan is a Haskell static analysis tool. It was created recently, but it already gained some attraction in the Haskell community.