### PR TITLE
Specify Stan as a Haskell-only static analyser

### DIFF
--- a/data/tools.yml
+++ b/data/tools.yml
@@ -3387,5 +3387,3 @@
   description: Stan is a command-line tool for analysing Haskell projects and outputting discovered vulnerabilities in a helpful way with possible solutions for detected problems.
   tags:
     - haskell
-    - configfile
-    - json


### PR DESCRIPTION
Thanks for adding Stan to the list, @mre!

When looking at the final README, I see that Stan is listed in the `Multiple languages` section. However, this tool analyses only Haskell source code. I think that the `Haskell` section is a more suitable place for Stan.

I believe this is happening due to specification of multiple tags. The CONTRIBUTING guide suggests to add as many tags as possible. So I've added the `json` tag because Stan can produce JSON output and `configfile` since Stan has a configuration specified in the TOML format. I thought, that since `haskell` is the only tag with the `language` type and both `json` and `configfile` has the `other` type, Stan will appear in the `Haskell` section, but this doesn't seem to be the case. Thus, I'm happy to drop extra tags to list Stan under the Haskell category.