### PR TITLE
Luanalysis

### DIFF
--- a/data/tools.yml
+++ b/data/tools.yml
@@ -3431,3 +3431,9 @@
     - c
     - cpp
   proprietary: true
+- name: Luanalysis
+  homepage: "https://plugins.jetbrains.com/plugin/14698-luanalysis"
+  source: "https://github.com/Benjamin-Dobell/IntelliJ-Luanalysis"
+  description: An IDE for statically typed Lua development.
+  tags:
+    - lua


### PR DESCRIPTION
I don't believe Luanalysis is eligible yet (too new). Nonetheless, I was instructed to submit a PR that may be merged at some later date (https://news.ycombinator.com/item?id=24223108).

Luanalysis started life as fork of [EmmyLua](https://github.com/EmmyLua/IntelliJ-EmmyLua) around December-January, but wasn't considered its own independent project until its 1.0.0 release in July:

![Screen Shot 2020-08-20 at 11 50 01 pm](https://user-images.githubusercontent.com/482276/90778409-ee60fd80-e33f-11ea-8ced-7e0911f4b1b8.png)
