### PR TITLE
Remove Kiuwan duplicate

### DIFF
--- a/data/tools.yml
+++ b/data/tools.yml
@@ -1706,12 +1706,6 @@
     - service
     - swift
   proprietary: true
-- name: kiuwan
-  homepage: "https://www.kiuwan.com/"
-  description: Software Analytics in the Cloud supporting more than 22 programming languages.
-  tags:
-    - service
-  proprietary: true
 - name: Klocwork
   homepage: "https://www.perforce.com/products/klocwork"
   description: "Quality and Security Static analysis for C/C++, Java and C#."


### PR DESCRIPTION
This tool was listed twice. The item I'm deleting right now was actually the original one, added in #10. The one that is still left looked more accurate to me, even though it got added with a few other tools in #149.