### PR TITLE
Add Unimport for Python

### DIFF
--- a/data/tools.yml
+++ b/data/tools.yml
@@ -3338,7 +3338,7 @@
   tags:
     - go
 - name: unimport
-  homepage: "https://unimport.hakancelik.dev/#/"
+  homepage: "https://unimport.hakancelik.dev"
   source: "https://github.com/hakancelik96/unimport"
   description: A linter, formatter for finding and removing unused import statements.
   tags:

--- a/data/tools.yml
+++ b/data/tools.yml
@@ -3337,6 +3337,12 @@
   description: Finds unnecessary import aliases.
   tags:
     - go
+- name: unimport
+  homepage: "https://unimport.hakancelik.dev/#/"
+  source: "https://github.com/hakancelik96/unimport"
+  description: A linter, formatter for finding and removing unused import statements.
+  tags:
+    - python
 - name: unparam
   homepage: "https://github.com/mvdan/unparam"
   source: "https://github.com/mvdan/unparam"


### PR DESCRIPTION
A linter, formatter for finding and removing unused import statements.

<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- New tools have to be added to `data/tools.yml` (NOT directly in the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->
