### PR TITLE
Create an optional `resources` section with links to videos and articles.

### DIFF
--- a/data/render/src/bin/main.rs
+++ b/data/render/src/bin/main.rs
@@ -13,6 +13,7 @@ struct Args {
     tags: PathBuf,
     tools: PathBuf,
     out: PathBuf,
+    skip_deprecated: bool,
 }
 
 fn parse_path(s: &OsStr) -> Result<PathBuf> {
@@ -52,6 +53,7 @@ fn main() -> Result<()> {
         tags: args.value_from_os_str("--tags", parse_path)?,
         tools: args.value_from_os_str("--tools", parse_path)?,
         out: args.value_from_os_str("--out", parse_path)?,
+        skip_deprecated: args.contains("--skip-deprecated"),
     };
 
     let tags = read_tags(args.tags)?;
@@ -59,8 +61,10 @@ fn main() -> Result<()> {
     tools.sort();
     validate(&tags, &tools)?;
 
+    if !args.skip_deprecated {
     if let Ok(token) = env::var("GITHUB_TOKEN") {
         check_deprecated(token, &mut tools)?;
+    }
     }
 
     let catalog = group(&tags, tools)?;

--- a/data/render/src/types.rs
+++ b/data/render/src/types.rs
@@ -1,6 +1,6 @@
 use askama::Template;
 use std::collections::{BTreeMap, HashSet};
-use std::{cmp::Ordering, collections::HashMap};
+use std::cmp::Ordering;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum Type {
@@ -25,6 +25,12 @@ pub type Tags = Vec<Tag>;
 pub type EntryTags = HashSet<String>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Resource {
+    title: String,
+    url: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Entry {
     pub name: String,
     pub categories: HashSet<String>,
@@ -36,13 +42,7 @@ pub struct Entry {
     pub description: String,
     pub discussion: Option<String>,
     pub deprecated: Option<bool>,
-    // The optional resources field is currently not parsed. It is only used
-    // for the website. In the future we could extend
-    // https://crates.io/crates/serde-tuple-vec-map to support optional fields
-    // or implement our own deserializer.
-    // Ideally we'd create a struct Resource { k: String, v: Url};
-    #[serde(skip_deserializing)]
-    pub resources: Option<Vec<(String, String)>>,
+    pub resources: Option<Vec<Resource>>,
     pub wrapper: Option<bool>,
 }
 

--- a/data/render/src/types.rs
+++ b/data/render/src/types.rs
@@ -1,6 +1,6 @@
 use askama::Template;
-use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashSet};
+use std::{cmp::Ordering, collections::HashMap};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum Type {
@@ -36,6 +36,13 @@ pub struct Entry {
     pub description: String,
     pub discussion: Option<String>,
     pub deprecated: Option<bool>,
+    // The optional resources field is currently not parsed. It is only used
+    // for the website. In the future we could extend
+    // https://crates.io/crates/serde-tuple-vec-map to support optional fields
+    // or implement our own deserializer.
+    // Ideally we'd create a struct Resource { k: String, v: Url};
+    #[serde(skip_deserializing)]
+    pub resources: Option<Vec<(String, String)>>,
     pub wrapper: Option<bool>,
 }
 

--- a/data/tools/appscan-source.yml
+++ b/data/tools/appscan-source.yml
@@ -26,3 +26,6 @@ types:
   - service
 homepage: "https://www.hcltechsw.com/wps/portal/products/appscan/home"
 description: Commercial Static Code Analysis.
+resources:
+  - title: Introducing HCL AppScan Standard
+    url: https://www.youtube.com/watch?v=TmYY67w18RI

--- a/data/tools/atom-beautify.yml
+++ b/data/tools/atom-beautify.yml
@@ -23,8 +23,10 @@ types:
 source: "https://github.com/Glavin001/atom-beautify"
 homepage: "https://atom.io/packages/atom-beautify"
 resources:
-  - Adding Atom Beautify Package to Atom: https://www.youtube.com/watch?v=oBz6rXG0XT8
-  - 10 Essential Atom Editor Packages & Setup: https://www.youtube.com/watch?v=aiXNKHKWlmY
+  - title: Adding Atom Beautify Package to Atom
+    url: https://www.youtube.com/watch?v=oBz6rXG0XT8
+  - title: 10 Essential Atom Editor Packages & Setup
+    url: https://www.youtube.com/watch?v=aiXNKHKWlmY
 description: >-
   Beautify HTML, CSS, JavaScript, PHP, Python, Ruby, Java, C, C++, C#,
   Objective-C, CoffeeScript, TypeScript, Coldfusion, SQL, and more in Atom

--- a/data/tools/atom-beautify.yml
+++ b/data/tools/atom-beautify.yml
@@ -22,6 +22,9 @@ types:
   - ide-plugin
 source: "https://github.com/Glavin001/atom-beautify"
 homepage: "https://atom.io/packages/atom-beautify"
+resources:
+  - Adding Atom Beautify Package to Atom: https://www.youtube.com/watch?v=oBz6rXG0XT8
+  - 10 Essential Atom Editor Packages & Setup: https://www.youtube.com/watch?v=aiXNKHKWlmY
 description: >-
   Beautify HTML, CSS, JavaScript, PHP, Python, Ruby, Java, C, C++, C#,
   Objective-C, CoffeeScript, TypeScript, Coldfusion, SQL, and more in Atom

--- a/data/tools/better-code-hub.yml
+++ b/data/tools/better-code-hub.yml
@@ -26,3 +26,6 @@ homepage: "https://bettercodehub.com"
 description: >-
   Better Code Hub checks your GitHub codebase against 10 engineering guidelines
   devised by the authority in software quality, Software Improvement Group.
+resources:
+  - title: Better Code Hub introduction video
+    url: https://www.youtube.com/watch?v=diERwdr2omM

--- a/data/tools/black-duck.yml
+++ b/data/tools/black-duck.yml
@@ -6,7 +6,10 @@ tags:
 license: proprietary
 types:
   - cli
-homepage: 'https://www.blackducksoftware.com'
+homepage: "https://www.blackducksoftware.com"
 description: >-
   Tool to analyze source code and binaries for reusable code, necessary licenses
   and potential security aspects.
+resources:
+  - title: Black Duck SCA & Coverity Static Analysis (SAST) Integrations with Amazon AWS CI Tools | Synopsys
+    url: https://www.youtube.com/watch?v=GEvxbU6EmiA

--- a/data/tools/black.yml
+++ b/data/tools/black.yml
@@ -6,6 +6,11 @@ tags:
 license: MIT License
 types:
   - cli
-source: 'https://github.com/ambv/black'
-homepage: 'https://black.readthedocs.io/en/stable'
+source: "https://github.com/psf/black"
+homepage: "https://black.readthedocs.io/en/stable"
 description: The uncompromising Python code formatter.
+resources:
+  - title: Using the black code formatter in Python
+    url: https://www.youtube.com/watch?v=InA-oAWu3Mo
+  - title: "Łukasz Langa - Life Is Better Painted Black, or: How to Stop Worrying and Embrace Auto-Formatting"
+    url: https://www.youtube.com/watch?v=esZLCuWs_2Y

--- a/data/tools/codescene.yml
+++ b/data/tools/codescene.yml
@@ -30,3 +30,10 @@ description: >-
   CodeScene is a quality visualization tool for software. Prioritize technical
   debt, detect delivery risks, and measure organizational aspects. Fully
   automated.
+resources:
+  - title: CodeScene Introduction - short video with the essentials of CodeScene
+    url: https://www.youtube.com/watch?v=4Mwv-Swxo84
+  - title: Augmented Code Analysis with CodeScene
+    url: https://www.youtube.com/watch?v=c2lqk98bC00
+  - title: "Beyond code: interview with Adam Tornhill about CodeScene"
+    url: https://www.youtube.com/watch?v=tbCA2JiO_K8

--- a/data/tools/cognicrypt.yml
+++ b/data/tools/cognicrypt.yml
@@ -6,6 +6,9 @@ tags:
 license: Eclipse Public License 2.0
 types:
   - cli
-source: 'https://github.com/eclipse-cognicrypt/CogniCrypt'
-homepage: 'https://www.eclipse.org/cognicrypt'
+source: "https://github.com/eclipse-cognicrypt/CogniCrypt"
+homepage: "https://www.eclipse.org/cognicrypt"
 description: Checks Java source and byte code for incorrect uses of cryptographic APIs.
+resources:
+  - title: "Tutorial: CogniCrypt basics, and how to integrate your own Crypto APIs into CognICrypt"
+    url: https://www.youtube.com/watch?v=vOZKN8yQcAY

--- a/data/tools/coverity.yml
+++ b/data/tools/coverity.yml
@@ -24,3 +24,6 @@ description: >-
   Synopsys Coverity supports 20 languages and over 70 frameworks including Ruby
   on rails, Scala, PHP, Python, JavaScript, TypeScript, Java, Fortran, C, C++,
   C#, VB.NET.
+resources:
+  - title: Checkmarx - Source Code Analysis Made Easy 2017
+    url: https://www.youtube.com/watch?v=zo1pCl6yQ34

--- a/data/tools/deepcode.yml
+++ b/data/tools/deepcode.yml
@@ -18,3 +18,8 @@ description: >-
   real time and deliver results when you hit the save button in your IDE.
   Supported languages are Java, C/C++, JavaScript, Python, and TypeScript.
   Integrations with GitHub, BitBucket and Gitlab.
+resources:
+  - title: Intro to DeepCode
+    url: https://www.youtube.com/watch?v=5ThvYN3nWcg
+  - title: How DeepCode addresses False Positives
+    url: https://www.youtube.com/watch?v=d-fvZ83O_es

--- a/data/tools/eslint.yml
+++ b/data/tools/eslint.yml
@@ -6,6 +6,9 @@ tags:
 license: Other
 types:
   - cli
-source: 'https://github.com/typescript-eslint/typescript-eslint'
-homepage: 'https://github.com/typescript-eslint/typescript-eslint'
+source: "https://github.com/typescript-eslint/typescript-eslint"
+homepage: "https://github.com/typescript-eslint/typescript-eslint"
 description: An extensible linter for the TypeScript language.
+resources:
+  - title: VSCode ESLint, Prettier & Airbnb Style Guide Setup
+    url: https://www.youtube.com/watch?v=SydnKbGc7W8

--- a/data/tools/flake8.yml
+++ b/data/tools/flake8.yml
@@ -7,6 +7,9 @@ tags:
 license: Other
 types:
   - cli
-source: 'https://github.com/PyCQA/flake8'
-homepage: 'https://github.com/PyCQA/flake8'
-description: 'A wrapper around `pyflakes`, `pycodestyle` and `mccabe`.'
+source: "https://github.com/PyCQA/flake8"
+homepage: "https://github.com/PyCQA/flake8"
+description: "A wrapper around `pyflakes`, `pycodestyle` and `mccabe`."
+resources:
+  - title: My Python Code Looks Ugly and Confusing - Help!
+    url: https://www.youtube.com/watch?v=TDUf93vqq3g

--- a/data/tools/fortify.yml
+++ b/data/tools/fortify.yml
@@ -38,3 +38,6 @@ description: >-
   VB.NET, VB6, ABAP/BSP, ActionScript, Apex, ASP.NET, Classic ASP, VB Script,
   Cobol, ColdFusion, HTML, Java, JS, JSP, MXML/Flex, Objective-C, PHP, PL/SQL,
   T-SQL, Python (2.6, 2.7), Ruby (1.9.3), Swift, Scala, VB, and XML.
+resources:
+  - title: Visual Studio - real-time security with Fortify Security Assistant (2018)
+    url: https://www.youtube.com/watch?v=7CfeUXtDlwQ

--- a/data/tools/golangci-lint.yml
+++ b/data/tools/golangci-lint.yml
@@ -6,6 +6,9 @@ tags:
 license: GNU General Public License v3.0
 types:
   - cli
-source: 'https://github.com/golangci/golangci-lint'
-homepage: 'https://golangci-lint.run'
-description: 'Alternative to `Go Meta Linter`: GolangCI-Lint is a linters aggregator.'
+source: "https://github.com/golangci/golangci-lint"
+homepage: "https://golangci-lint.run"
+description: "Alternative to `Go Meta Linter`: GolangCI-Lint is a linters aggregator."
+resources:
+  - title: "GopherCon 2019: Denis Isaev (author of golangci-lint) - Go Linters: Myths and Best Practices"
+    url: https://www.youtube.com/watch?v=1U-Gzz4TYP0

--- a/data/tools/prettier.yml
+++ b/data/tools/prettier.yml
@@ -8,6 +8,11 @@ tags:
 license: MIT License
 types:
   - cli
-source: 'https://github.com/prettier/prettier'
-homepage: 'https://prettier.io'
+source: "https://github.com/prettier/prettier"
+homepage: "https://prettier.io"
 description: An opinionated code formatter.
+resources:
+  - title: Code Formatting with Prettier in Visual Studio Code
+    url: https://www.youtube.com/watch?v=h3PJjP0nE98
+  - title: VSCode ESLint, Prettier & Airbnb Style Guide Setup
+    url: https://www.youtube.com/watch?v=SydnKbGc7W8

--- a/data/tools/pvs-studio.yml
+++ b/data/tools/pvs-studio.yml
@@ -16,3 +16,10 @@ description: >-
   advertising purposes [you can propose a large FOSS project for analysis by PVS
   employees](https://github.com/viva64/pvs-studio-check-list). Supports CWE
   mapping, MISRA and CERT coding standards.
+resources:
+  - title: PVS-Studio is now in Compiler Explorer!
+    url: https://www.youtube.com/watch?v=hw5npZqB3b8
+  - title: PVS-Studio in 2019
+    url: https://www.youtube.com/watch?v=FkfMGqxIR-I
+  - title: Static Analysis in C++ (mostly about PVS-Studio)
+    url: https://www.youtube.com/watch?v=vYW6TOwFK2M

--- a/data/tools/pysa.yml
+++ b/data/tools/pysa.yml
@@ -6,8 +6,11 @@ tags:
 license: MIT License
 types:
   - cli
-source: 'https://github.com/facebook/pyre-check'
-homepage: 'https://pyre-check.org/docs/pysa-basics.html'
+source: "https://github.com/facebook/pyre-check"
+homepage: "https://pyre-check.org/docs/pysa-basics.html"
 description: >-
   A tool based on Facebook's pyre-check to identify potential security issues in
   Python code identified with taint analysis.
+resources:
+  - title: "Workshop: Graham Bleaney - Pysa to Identify Python Vulnerabilities - DEF CON 28SM AppSec Village"
+    url: https://www.youtube.com/watch?v=8I3zlvtpOww

--- a/data/tools/reshift.yml
+++ b/data/tools/reshift.yml
@@ -7,7 +7,10 @@ tags:
 license: proprietary
 types:
   - service
-homepage: 'https://www.reshiftsecurity.com'
+homepage: "https://www.reshiftsecurity.com"
 description: >-
   A source code analysis tool for detecting and managing Java security
   vulnerabilities.
+resources:
+  - title: 3 Minute Reshift Demo 2020
+    url: https://www.youtube.com/watch?v=GspuLMF3Vyo

--- a/data/tools/sonarqube.yml
+++ b/data/tools/sonarqube.yml
@@ -22,3 +22,8 @@ types:
 source: "https://github.com/SonarSource/sonarqube"
 homepage: "http://www.sonarqube.org"
 description: SonarQube is an open platform to manage code quality.
+resources:
+  - title: Write Cleaner, Safer, Modern C++ Code with SonarQube
+    url: https://www.youtube.com/watch?v=WPHVPbxCAwE
+  - title: Write cleaner, safer Python code with SonarQube
+    url: https://www.youtube.com/watch?v=ow-yuIlCuHk

--- a/data/tools/teamscale.yml
+++ b/data/tools/teamscale.yml
@@ -12,8 +12,11 @@ license: proprietary
 types:
   - service
   - ide-plugin
-homepage: 'http://www.teamscale.com'
+homepage: "http://www.teamscale.com"
 description: >-
   Static and dynamic analysis tool supporting more than 25 languages and direct
   IDE integration. Free hosting for Open Source projects available on request.
   Free academic licenses available.
+resources:
+  - title: "CQSE Webinar: Architekturanalyse mit Teamscale (German)"
+    url: https://www.youtube.com/watch?v=fJVjv0153-U

--- a/data/tools/veracode.yml
+++ b/data/tools/veracode.yml
@@ -14,8 +14,13 @@ tags:
 license: proprietary
 types:
   - cli
-homepage: 'http://www.veracode.com/products/static-analysis-sast/static-code-analysis'
+homepage: "http://www.veracode.com/products/static-analysis-sast/static-code-analysis"
 description: >-
   Find flaws in binaries and bytecode without requiring source. Support all
   major programming languages: Java, .NET, JavaScript, Swift, Objective-C, C,
   C++ and more.
+resources:
+  - title: Veracode Overview
+    url: https://www.youtube.com/watch?v=6Fq_UMgwX4I
+  - title: Ten Years in the Making - Veracode (behind the scenes)
+    url: https://www.youtube.com/watch?v=CacOX9ytugc


### PR DESCRIPTION
Some entries can be enriched with external links.
These can be websites, PDFs, or videos.
This PR adds support for an optional `resources` field.
For now we only plan to use it on the website as the
rendering on the `README.md` could get a little cluttered.
Nevertheless I think it's a good idea to keep all data
in the repo.