### PR TITLE
[Python] Add fixit.

### DIFF
--- a/data/tools/fixit.yml
+++ b/data/tools/fixit.yml
@@ -1,0 +1,14 @@
+name: fixit
+categories:
+  - linter
+tags:
+  - python
+license: MIT
+types:
+  - cli
+source: 'https://github.com/Instagram/Fixit'
+homepage: 'https://pypi.org/project/fixit'
+description: A framework for creating lint rules and corresponding auto-fixes for source code.
+resources:
+  - title: Enforcing coding conventions using libCST and Fixit
+    url: https://www.digitalernachschub.de/blog/enforcing-coding-conventions-using-libcst-and-fixit/


### PR DESCRIPTION
Fixit allows the creation of custom lint rules, just like flake8 or pylint. In addition, fixit allows developers to apply code transformations, similar to 2to3.

`flake8`/`pyflakes` and pylint use the `ast` or `astroid` modules to analyze the source code. The resulting abstract syntax tree is missing information, such as whether a string was surrounded by single or double quotes, or the number of whitespaces between two tokens. Fixit is based on `libCST`, which uses a concrete syntax tree as its base representation and retains all formatting.

Therefore, Fixit is not just a framework for lint rules, but a framework for code transformations. This can be used to enforce coding conventions or to ascertain certain properties of the source code like HTTP request timeouts.

Although Fixit is relatively new, the underlying libCST library is quite mature and does most of the heavy lifitng.