### PR TITLE
add todocheck to list of linters

### DIFF
--- a/data/tools/todocheck.yml
+++ b/data/tools/todocheck.yml
@@ -1,0 +1,25 @@
+name: todocheck
+categories:
+  - linter
+tags:
+  - javascript
+  - typescript
+  - python
+  - c
+  - cpp
+  - scala
+  - java
+  - rust
+  - swift
+  - go
+  - groovy
+  - csharp
+  - shell
+  - php
+  - r
+license: MIT
+types:
+  - cli
+source: 'https://github.com/preslavmihaylov/todocheck'
+homepage: 'https://github.com/preslavmihaylov/todocheck'
+description: Linter for integrating annotated TODOs with your issue trackers


### PR DESCRIPTION
Hey, wanted to submit a tool I created to this list as it seems to satisfy the requirements:
 * More than 20 stars (currently ~300)
 * More than one contributor (There are three contributors in total so far)
 * More than 3 months old (Project was released in July 2020)