### PR TITLE
Adding diKTat (Kotlin linter) to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,6 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 
 - [detekt](https://detekt.github.io/detekt) - Static code analysis for Kotlin code.
 - [ktlint](https://ktlint.github.io) - An anti-bikeshedding Kotlin linter with built-in formatter.
-- [diktat](https://www.cqfn.org/diKTat/) - Strict coding standard for Kotlin and a linter that detects and auto-fixes code smells.
 
 
 <h2 id="lua">Lua</h2>

--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 
 - [detekt](https://detekt.github.io/detekt) - Static code analysis for Kotlin code.
 - [ktlint](https://ktlint.github.io) - An anti-bikeshedding Kotlin linter with built-in formatter.
+- [diktat](https://www.cqfn.org/diKTat/) - Strict coding standard for Kotlin and a linter that detects and auto-fixes code smells.
 
 
 <h2 id="lua">Lua</h2>

--- a/data/tools/diktat.yml
+++ b/data/tools/diktat.yml
@@ -1,0 +1,12 @@
+name: diktat
+categories:
+  - linter
+  - formatter
+tags:
+  - kotlin
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/cqfn/diKTat'
+homepage: 'https://www.cqfn.org/diKTat'
+description: Strict coding standard for Kotlin and a linter that detects and auto-fixes code smells.


### PR DESCRIPTION
### What is diKTat:
1) DiKTat is a formal and strict code style for Kotlin with implementation in a linter.
2) DiKTat is a collection of Kotlin code style rules implemented as AST visitors on top of KTlint framework. This linter can validate (check) and automatically fix (format) the code. The set of rules (visitors) is bigger than in ktlint standard set of rules (~100 inspections already). All rules are highly configurable.
3) DiKTat is used to detect (and partially fix) code-style issues, codesmells and bugs in code. And comparing to other linters - it has a very strict and properly documented code-style that it is implementing. But anyway gives a chance to configure or suppress inspections (from code or using configuration file).
4) DiKTat can be run with it's own maven plugin/gradle plugin/cli
5) DiKTat has been added to awesome-kotlin list:
   https://github.com/KotlinBy/awesome-kotlin/blob/readme/README.md#tools-back-

