### PR TITLE
AWS CloudFormation Guard

### DIFF
--- a/data/tools/cloudformation-guard.yml
+++ b/data/tools/cloudformation-guard.yml
@@ -1,0 +1,13 @@
+name: AWS CloudFormation Guard
+categories:
+  - linter
+tags:
+  - configmanagement
+license: Apache License 2.0
+types:
+  - cli
+source: 'https://github.com/aws-cloudformation/cloudformation-guard'
+homepage: 'https://github.com/aws-cloudformation/cloudformation-guard'
+description: >-
+  Check local CloudFormation templates against policy-as-code rules 
+  and generate rules from existing templates.


### PR DESCRIPTION
CloudFormation Guard A CLI tool that
- Checks AWS CloudFormation templates for policy compliance using a simple, policy-as-code, declarative syntax
- Can autogenerate rules from existing CloudFormation templates

<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- New tools have to be added to `data/tools/` (NOT directly in the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->
