### PR TITLE
Separate TS ESlint and ESlint

### DIFF
--- a/data/tags.yml
+++ b/data/tags.yml
@@ -70,6 +70,9 @@
 - name: "F#"
   tag: fsharp
   type: language
+- name: "Flow"
+  tag: flow
+  type: language
 - name: Fortran
   tag: fortran
   type: language

--- a/data/tools/eslint.yml
+++ b/data/tools/eslint.yml
@@ -6,7 +6,7 @@ tags:
   - typescript
   - jsx
   - flow
-license: Other
+license: MIT License
 types:
   - cli
 source: "https://github.com/eslint/eslint"

--- a/data/tools/eslint.yml
+++ b/data/tools/eslint.yml
@@ -2,13 +2,16 @@ name: ESLint
 categories:
   - linter
 tags:
+  - javascript
   - typescript
+  - jsx
+  - flow
 license: Other
 types:
   - cli
-source: "https://github.com/typescript-eslint/typescript-eslint"
-homepage: "https://github.com/typescript-eslint/typescript-eslint"
-description: An extensible linter for the TypeScript language.
+source: "https://github.com/eslint/eslint"
+homepage: "https://github.com/eslint/eslint"
+description: An extensible linter for JS, following the ECMAScript standard.
 resources:
   - title: VSCode ESLint, Prettier & Airbnb Style Guide Setup
     url: https://www.youtube.com/watch?v=SydnKbGc7W8

--- a/data/tools/typescript-eslint.yml
+++ b/data/tools/typescript-eslint.yml
@@ -1,0 +1,14 @@
+name: TypeScript ESLint
+categories:
+  - linter
+tags:
+  - typescript
+license: Other
+types:
+  - cli
+source: "https://github.com/typescript-eslint/typescript-eslint"
+homepage: "https://github.com/typescript-eslint/typescript-eslint"
+description: TypeScript language extension for eslint.
+resources:
+  - title: VSCode ESLint, Prettier & Airbnb Style Guide Setup
+    url: https://www.youtube.com/watch?v=SydnKbGc7W8


### PR DESCRIPTION
This PR separates 'ESlint' and 'Typescript ESlint'. 

The current entry treats ESlint as Typescript first, linking to the 'Typescript ESlint' project, which is in accurate. In this contribution we trying to clarify that ESlint is Javscript/ECMAScript first and that 'Typescript ESlint' is an extension for TS.

Also, since ESlint supports more than the base JS, I have updated the tags to reflect this.

<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->
