### PR TITLE
Remove tailor.sh website

### DIFF
--- a/data/tools/tailor.yml
+++ b/data/tools/tailor.yml
@@ -8,7 +8,7 @@ license: MIT License
 types:
   - cli
 source: 'https://github.com/sleekbyte/tailor'
-homepage: 'https://tailor.sh'
+homepage: 'https://github.com/sleekbyte/tailor'
 description: >-
   A static analysis and lint tool for source code written in Apple's Swift
   programming language.


### PR DESCRIPTION
The tool is deprecated for a while but now the website is also down

<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->
