### PR TITLE
Added new Infer# tool

### DIFF
--- a/data/tools/infersharp.yml
+++ b/data/tools/infersharp.yml
@@ -8,4 +8,7 @@ types:
   - cli
 source: 'https://github.com/microsoft/infersharp'
 homepage: 'https://github.com/microsoft/infersharp'
-description: 'InferSharp (also referred to as Infer#) is an interprocedural and scalable static code analyzer for C#. Via the capabilities of Facebook's Infer, this tool detects null pointer dereferences and resource leak.'
+description: >-
+  InferSharp (also referred to as Infer#) is an interprocedural and 
+  scalable static code analyzer for C#. Via the capabilities of Facebook's Infer, 
+  this tool detects null pointer dereferences and resource leaks.

--- a/data/tools/infersharp.yml
+++ b/data/tools/infersharp.yml
@@ -1,5 +1,3 @@
-[Infer#](https://github.com/microsoft/infersharp) - Infer#: Interprocedural Memory Safety Analysis For C#
-
 name: Infer#
 categories:
   - linter

--- a/data/tools/infersharp.yml
+++ b/data/tools/infersharp.yml
@@ -2,7 +2,7 @@ name: Infer#
 categories:
   - linter
 tags:
-  - c#
+  - csharp
 license: MIT License
 types:
   - cli

--- a/data/tools/infersharp.yml
+++ b/data/tools/infersharp.yml
@@ -1,0 +1,13 @@
+[Infer#](https://github.com/microsoft/infersharp) - Infer#: Interprocedural Memory Safety Analysis For C#
+
+name: Infer#
+categories:
+  - linter
+tags:
+  - c#
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/microsoft/infersharp'
+homepage: 'https://github.com/microsoft/infersharp'
+description: 'InferSharp (also referred to as Infer#) is an interprocedural and scalable static code analyzer for C#. Via the capabilities of Facebook's Infer, this tool detects null pointer dereferences and resource leak.'


### PR DESCRIPTION
Based on [this article](https://devblogs.microsoft.com/dotnet/infer-interprocedural-memory-safety-analysis-for-c/) it looks like this new tool is gaining traction with 186 stars and 17 watchers.

<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->
