### PR TITLE
Add SQLFluff

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ Dialyzer starts its analysis from either debug-compiled BEAM bytecode  or from E
 <h2 id="sql">SQL</h2>
 
 - [sqlcheck](https://github.com/jarulraj/sqlcheck) - Automatically identify anti-patterns in SQL queries.
+- [SQLFluff](https://www.sqlfluff.com/) - Multiple dialect SQL linter and formatter.
 - [sqlint](https://github.com/purcell/sqlint) - Simple SQL linter.
 - [tsqllint](https://github.com/tsqllint/tsqllint) - T-SQL-specific linter.
 - [TSqlRules](https://github.com/ashleyglee/TSqlRules) - TSQL Static Code Analysis Rules for SQL Server.

--- a/data/tools/sqlfluff.yml
+++ b/data/tools/sqlfluff.yml
@@ -12,4 +12,4 @@ homepage: 'https://www.sqlfluff.com/'
 description: Multiple dialect SQL linter and formatter.
 resources:
   - title: Official SQLFluff documentation
-  - url: https://docs.sqlfluff.com/en/stable/
+    url: https://docs.sqlfluff.com/en/stable/

--- a/data/tools/sqlfluff.yml
+++ b/data/tools/sqlfluff.yml
@@ -1,0 +1,15 @@
+name: SQLFluff
+categories:
+  - linter
+  - formatter
+tags:
+  - sql
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/sqlfluff/sqlfluff'
+homepage: 'https://www.sqlfluff.com/'
+description: Multiple dialect SQL linter and formatter.
+resources:
+  - title: Official SQLFluff documentation
+  - url: https://docs.sqlfluff.com/en/stable/


### PR DESCRIPTION
Adds [SQLFluff](https://github.com/sqlfluff/sqlfluff), a sql linter and formatter with 368 stars.

<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

x- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
x- If you propose to deprecate a tool, you have to provide a reason below.
x- More details in the contributors guide, `CONTRIBUTING.md`

-->
