### PR TITLE
Add machine-readable JSON output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: render
 render:
-	cargo run --manifest-path data/render/Cargo.toml -- --tags data/tags.yml --tools data/tools --out README.md
+	cargo run --manifest-path data/render/Cargo.toml -- --tags data/tags.yml --tools data/tools --md-out README.md --json-out data/api/tools.json
 
 .PHONY: render-skip-deprecated
 render-skip-deprecated:
-	cargo run --manifest-path data/render/Cargo.toml -- --tags data/tags.yml --tools data/tools --out README.md --skip-deprecated
+	cargo run --manifest-path data/render/Cargo.toml -- --tags data/tags.yml --tools data/tools --md-out README.md --json-out data/api/tools.json --skip-deprecated

--- a/data/api/README.md
+++ b/data/api/README.md
@@ -1,0 +1,14 @@
+# API
+
+This directory contains a machine-readable JSON files from all static analysis
+tools in the repo. The files can be used to create your own API endpoints from
+the data, for running more complicated queries on the command-line with `jq`, or
+for using them inside a Jupyter notebook.
+
+The data format is subject to change as we use it for rendering the [website].
+
+The files in this directory are not meant to be edited directly. Instead, update
+the `.yml` files in the `/data/tools` directory and render the JSON again by
+calling `make render` from the root directory.
+
+[website]: https://analysis-tools.dev

--- a/data/api/tools.json
+++ b/data/api/tools.json
@@ -1,0 +1,14733 @@
+{
+    ".NET Analyzers": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/DotNetAnalyzers",
+        "source": "https://github.com/DotNetAnalyzers",
+        "description": "An organization for the development of analyzers (diagnostics and code fixes) using the .NET Compiler Platform.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "APPscreener": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "abap",
+            "c",
+            "csharp",
+            "cpp",
+            "delphi",
+            "java",
+            "javascript",
+            "objectivec",
+            "php",
+            "plsql",
+            "python",
+            "ruby",
+            "scala",
+            "swift",
+            "tsql",
+            "vbasic"
+        ],
+        "other": [
+            "html",
+            "smart-contracts"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://solarappscreener.com",
+        "source": null,
+        "description": "Static code analysis for binary and source code - Java/Scala, PHP, Javascript, C#, PL/SQL, Python, T-SQL, C/C++, ObjectiveC/Swift, Visual Basic 6.0, Ruby, Delphi, ABAP, HTML5 and Solidity.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "AWS CloudFormation Guard": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/aws-cloudformation/cloudformation-guard",
+        "source": "https://github.com/aws-cloudformation/cloudformation-guard",
+        "description": "Check local CloudFormation templates against policy-as-code rules  and generate rules from existing templates.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "After the Deadline": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "writing"
+        ],
+        "licenses": [
+            "GPL v2"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://open.afterthedeadline.com",
+        "source": "https://open.afterthedeadline.com",
+        "description": "Spell, style and grammar checker.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "Android Lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "mobile"
+        ],
+        "licenses": [
+            "Android Software Development Kit License Agreement"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://tools.android.com/tips/lint",
+        "source": "https://android.googlesource.com",
+        "description": "Run static analysis on Android projects.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Android Studio": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java",
+            "kotlin"
+        ],
+        "other": [],
+        "licenses": [
+            "Android Software Development Kit License Agreement"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://developer.android.com/studio",
+        "source": "https://android.googlesource.com/platform/tools/adt/idea/+/refs/heads/mirror-goog-studio-master-dev",
+        "description": "Based on IntelliJ IDEA, and comes bundled with tools for Android including Android Lint.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Angular ESLint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "typescript"
+        ],
+        "other": [
+            "angular",
+            "html"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/angular-eslint/angular-eslint#readme",
+        "source": "https://github.com/angular-eslint/angular-eslint",
+        "description": "Linter for Angular projects",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "AppChecker": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "java",
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://npo-echelon.ru/en/solutions/appchecker.php",
+        "source": null,
+        "description": "Static analysis for C/C++/C#, PHP and Java.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Application Inspector": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "asp",
+            "c",
+            "csharp",
+            "cpp",
+            "java",
+            "javascript",
+            "objectivec",
+            "php",
+            "sql",
+            "swift",
+            "vbnet"
+        ],
+        "other": [
+            "html",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.ptsecurity.com/ww-en/products/ai",
+        "source": null,
+        "description": "Commercial Static Code Analysis which generates exploits to verify vulnerabilities.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ApplicationInspector": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "go",
+            "java",
+            "javascript",
+            "objectivec",
+            "php",
+            "powershell",
+            "python",
+            "ruby"
+        ],
+        "other": [
+            "html"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/microsoft/ApplicationInspector",
+        "source": "https://github.com/microsoft/ApplicationInspector",
+        "description": "Creates reports of over 400 rule patterns for feature detection (e.g. the use of cryptography or version control in apps).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ArchUnit": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java",
+            "kotlin"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.archunit.org",
+        "source": "https://github.com/TNG/ArchUnit",
+        "description": "Unit test your Java or Kotlin architecture.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ArchUnitNET": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/TNG/ArchUnitNET",
+        "source": "https://github.com/TNG/ArchUnitNET",
+        "description": "A C# architecture test library to specify and assert architecture rules in C# for automated testing.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Astrée": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.absint.com/astree/index.htm",
+        "source": null,
+        "description": "Astrée automatically proves the absence of runtime errors and invalid con­current behavior in C/C++ applications. It is sound for floating-point computations, very fast, and exceptionally precise. The analyzer also checks for MISRA/CERT/CWE/Adaptive Autosar coding rules and supports qualification for ISO 26262, DO-178C level A, and other safety standards. Jenkins and Eclipse plugins are available.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Atom-Beautify": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "coffeescript",
+            "coldfusion",
+            "java",
+            "javascript",
+            "objectivec",
+            "php",
+            "python",
+            "ruby",
+            "sql",
+            "typescript"
+        ],
+        "other": [
+            "css",
+            "html"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://atom.io/packages/atom-beautify",
+        "source": "https://github.com/Glavin001/atom-beautify",
+        "description": "Beautify HTML, CSS, JavaScript, PHP, Python, Ruby, Java, C, C++, C#, Objective-C, CoffeeScript, TypeScript, Coldfusion, SQL, and more in Atom editor.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Adding Atom Beautify Package to Atom",
+                "url": "https://www.youtube.com/watch?v=oBz6rXG0XT8"
+            },
+            {
+                "title": "10 Essential Atom Editor Packages & Setup",
+                "url": "https://www.youtube.com/watch?v=aiXNKHKWlmY"
+            }
+        ],
+        "wrapper": null
+    },
+    "Axivion Bauhaus Suite": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "java",
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.axivion.com/en/products-services-9#products_bauhaussuite",
+        "source": null,
+        "description": "Tracks down error-prone code locations, style violations, cloned or dead code, cyclic dependencies and more for C/C++, C#/.NET, Java and Ada 83/Ada 95.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "AzSK": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "arm",
+            "configmanagement",
+            "ci",
+            "security"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://azsk.azurewebsites.net/",
+        "source": "https://github.com/azsk/DevOpsKit",
+        "description": "Secure DevOps kit for Azure (AzSK) provides security IntelliSense, Security Verification Tests (SVTs), CICD scan vulnerabilities, compliance issues, and infrastructure misconfiguration in your infrastructure-as-code. Supports Azure via ARM.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Better Code Hub": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp",
+            "cpp",
+            "go",
+            "groovy",
+            "java",
+            "javascript",
+            "kotlin",
+            "objectivec",
+            "perl",
+            "php",
+            "python",
+            "ruby",
+            "scala",
+            "shell",
+            "swift",
+            "typescript"
+        ],
+        "other": [
+            "smart-contracts"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://bettercodehub.com",
+        "source": null,
+        "description": "Better Code Hub checks your GitHub codebase against 10 engineering guidelines devised by the authority in software quality, Software Improvement Group.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Better Code Hub introduction video",
+                "url": "https://www.youtube.com/watch?v=diERwdr2omM"
+            }
+        ],
+        "wrapper": null
+    },
+    "BinSkim": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Microsoft/binskim",
+        "source": "https://github.com/Microsoft/binskim",
+        "description": "A binary static analysis tool that provides security and correctness results for Windows portable executables.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Black": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://black.readthedocs.io/en/stable",
+        "source": "https://github.com/psf/black",
+        "description": "The uncompromising Python code formatter.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Using the black code formatter in Python",
+                "url": "https://www.youtube.com/watch?v=InA-oAWu3Mo"
+            },
+            {
+                "title": "Łukasz Langa - Life Is Better Painted Black, or: How to Stop Worrying and Embrace Auto-Formatting",
+                "url": "https://www.youtube.com/watch?v=esZLCuWs_2Y"
+            }
+        ],
+        "wrapper": null
+    },
+    "Black Duck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.blackducksoftware.com",
+        "source": null,
+        "description": "Tool to analyze source code and binaries for reusable code, necessary licenses and potential security aspects.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Black Duck SCA & Coverity Static Analysis (SAST) Integrations with Amazon AWS CI Tools | Synopsys",
+                "url": "https://www.youtube.com/watch?v=GEvxbU6EmiA"
+            }
+        ],
+        "wrapper": null
+    },
+    "Bootlint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "html"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/twbs/bootlint",
+        "source": "https://github.com/twbs/bootlint",
+        "description": "An HTML linter for Bootstrap projects.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Bowler": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pybowler.io/",
+        "source": "https://github.com/facebookincubator/bowler",
+        "description": "Safe code refactoring for modern Python.  Bowler is a refactoring tool for manipulating Python at the syntax tree level.  It enables safe, large scale code modifications while guaranteeing that the  resulting code compiles and runs. It provides both a simple command line interface  and a fluent API in Python for generating complex code modifications in code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "C2Rust": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://c2rust.com",
+        "source": "https://github.com/immunant/c2rust",
+        "description": "C2Rust helps you migrate C99-compliant code to Rust. The translator (or transpiler) produces unsafe Rust code that closely mirrors the input C code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CAST Highlight": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "abap",
+            "c",
+            "csharp",
+            "cpp",
+            "cobol",
+            "java",
+            "javascript",
+            "jsp",
+            "php",
+            "plsql",
+            "python",
+            "tsql",
+            "vbasic"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.castsoftware.com/products/highlight",
+        "source": null,
+        "description": "Commercial Static Code Analysis which runs locally, but uploads the results to its cloud for presentation.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CBMC": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD-4-Clause-UC"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.cprover.org/cbmc",
+        "source": "https://github.com/diffblue/cbmc",
+        "description": "Bounded model-checker for C programs, user-defined assertions, standard assertions, several coverage metric analyses.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CMetrics": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/MetricsGrimoire/CMetrics",
+        "source": "https://github.com/MetricsGrimoire/CMetrics",
+        "description": "Measures size and complexity for C files.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CPAchecker": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache 2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://cpachecker.sosy-lab.org",
+        "source": "https://cpachecker.sosy-lab.org/download.php",
+        "description": "A tool for configurable software verification of C programs.  The name CPAchecker was chosen to reflect that the tool is based on the CPA concepts and is used for checking software programs.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CSS Stats": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "css"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://cssstats.com",
+        "source": "https://github.com/cssstats/cssstats",
+        "description": "Potentially interesting stats on stylesheets.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CSSLint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "css"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://csslint.net",
+        "source": "https://github.com/CSSLint/csslint",
+        "description": "Does basic syntax checking and finds problematic patterns or signs of inefficiency.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CSScomb": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [],
+        "other": [
+            "css"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/csscomb/csscomb.js",
+        "source": "https://github.com/csscomb/csscomb.js",
+        "description": "A coding style formatter for CSS. Supports own configurations to make style sheets beautiful and consistent.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CScout": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.spinellis.gr/cscout",
+        "source": "https://github.com/dspinellis/cscout",
+        "description": "Complexity and quality metrics for for C and C preprocessor code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CSharpEssentials": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/DustinCampbell/CSharpEssentials",
+        "source": "https://github.com/DustinCampbell/CSharpEssentials",
+        "description": "C# Essentials is a collection of Roslyn diagnostic analyzers, code fixes and refactorings that make it easy to work with C# 6 language features.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Checker Framework": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "GPL with Classpath exception / MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://checkerframework.org",
+        "source": "https://github.com/typetools/checker-framework",
+        "description": "Pluggable type-checking for Java.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Checkmarx CxSAST": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "asp",
+            "apex",
+            "c",
+            "csharp",
+            "cpp",
+            "go",
+            "groovy",
+            "java",
+            "javascript",
+            "objectivec",
+            "perl",
+            "php",
+            "python",
+            "ruby",
+            "scala",
+            "swift",
+            "vbscript",
+            "vbasic",
+            "vbnet",
+            "visualforce"
+        ],
+        "other": [
+            "html",
+            "mobile",
+            "nodejs",
+            "phonegap",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.checkmarx.com/products/static-application-security-testing",
+        "source": null,
+        "description": "Commercial Static Code Analysis which doesn't require pre-compilation.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ChkTeX": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "latex"
+        ],
+        "licenses": [
+            "GNU Public License version 2 or greater"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.nongnu.org/chktex",
+        "source": "http://git.savannah.nongnu.org/cgit/chktex.git",
+        "description": "A linter for LaTex which catches some typographic errors LaTeX oversees.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ClassGraph": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "groovy",
+            "java",
+            "kotlin"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/classgraph/classgraph",
+        "source": "https://github.com/classgraph/classgraph",
+        "description": "A classpath and module path scanner for querying or visualizing class metadata or class relatedness.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Clayton": {
+        "categories": [
+            "foo"
+        ],
+        "languages": [
+            "apex",
+            "lwc",
+            "visualforce"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.getclayton.com/",
+        "source": null,
+        "description": "AI-powered code reviews for Salesforce. Secure your developments, enforce best practice and control your technical debt in real-time.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Closure Compiler": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://developers.google.com/closure/compiler",
+        "source": "https://github.com/google/closure-compiler",
+        "description": "A compiler tool to increase efficiency, reduce size, and provide code warnings in JavaScript files.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ClosureLinter": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/google/closure-linter",
+        "source": "https://github.com/google/closure-linter",
+        "description": "Ensures that all of your project's JavaScript code follows the guidelines in the Google JavaScript Style Guide. It can also automatically fix many common errors.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "Cobra": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ada",
+            "c",
+            "cpp",
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://spinroot.com/cobra",
+        "source": null,
+        "description": "Structural source code analyzer by NASA's Jet Propulsion Laboratory.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Codacy": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "apex",
+            "csharp",
+            "cpp",
+            "coffeescript",
+            "crystal",
+            "elixir",
+            "go",
+            "groovy",
+            "java",
+            "javascript",
+            "jsp",
+            "kotlin",
+            "php",
+            "plsql",
+            "python",
+            "ruby",
+            "scala",
+            "shell",
+            "swift",
+            "tsql",
+            "typescript",
+            "vbscript",
+            "visualforce"
+        ],
+        "other": [
+            "css",
+            "json",
+            "markdown",
+            "xml"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.codacy.com",
+        "source": null,
+        "description": "Code Analysis to ship Better Code, Faster.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Automate your code quality with Codacy Static Analysis Tool",
+                "url": "https://www.youtube.com/watch?v=oxqTu2ouxaw"
+            },
+            {
+                "title": "A founder's journey - Codacy",
+                "url": "https://www.youtube.com/watch?v=lVxkD_bmbFY"
+            }
+        ],
+        "wrapper": null
+    },
+    "Code Climate": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "AGPL-3.0 License"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://codeclimate.com",
+        "source": "https://github.com/codeclimate/codeclimate",
+        "description": "The open and extensible static analysis platform, for everyone.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Code Intelligence": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "go",
+            "java"
+        ],
+        "other": [
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.code-intelligence.com",
+        "source": null,
+        "description": "CI/CD-agnostic DevSecOps platform which combines industry-leading fuzzing engines for finding bugs and visualizing code coverage",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Code Intelligence | Introduction",
+                "url": "https://www.youtube.com/watch?v=Qfsz_ZTKM6Y"
+            }
+        ],
+        "wrapper": null
+    },
+    "CodeFactor": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "coffeescript",
+            "dart",
+            "go",
+            "groovy",
+            "java",
+            "javascript",
+            "kotlin",
+            "php",
+            "powershell",
+            "python",
+            "r",
+            "ruby",
+            "scala",
+            "shell",
+            "swift",
+            "typescript"
+        ],
+        "other": [
+            "container",
+            "ci",
+            "css",
+            "html",
+            "vue",
+            "yaml"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://codefactor.io",
+        "source": null,
+        "description": "Automated Code Analysis for repos on GitHub or BitBucket.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Getting started with CodeFactor.io",
+                "url": "https://www.youtube.com/watch?v=0wL1bgoya2U"
+            }
+        ],
+        "wrapper": null
+    },
+    "CodeFlow": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java",
+            "javascript",
+            "php",
+            "python",
+            "ruby",
+            "typescript"
+        ],
+        "other": [
+            "container",
+            "ci",
+            "css"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.getcodeflow.com",
+        "source": null,
+        "description": "Automated code analysis tool to deal with technical depth. Integrates with Bitbucket and Gitlab. (free for Open Source Projects)",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CodeIt.Right": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp",
+            "vbnet"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://submain.com/products/codeit.right.aspx",
+        "source": null,
+        "description": "CodeIt.Right&trade; provides a fast, automated way to ensure that your source code adheres to (your) predefined design and style guidelines as well as best coding practices.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CodeNarc": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "groovy"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://codenarc.github.io/CodeNarc",
+        "source": "https://github.com/CodeNarc/CodeNarc",
+        "description": "A static analysis tool for Groovy source code, enabling monitoring and enforcement of many coding standards and best practices.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CodePatrol": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp",
+            "java",
+            "javascript",
+            "php"
+        ],
+        "other": [
+            "ci",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://cyber-security.claranet.fr/en/codepatrol",
+        "source": null,
+        "description": "Automated SAST code reviews driven by security, supports 15+ languages and includes security training.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CodeRush": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "dotnet",
+            "aspnet",
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.devexpress.com/products/coderush",
+        "source": null,
+        "description": "Code creation, debugging, navigation, refactoring, analysis and visualization tools that use the Roslyn engine in Visual Studio 2015 and up.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CodeScan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "apex",
+            "lwc",
+            "visualforce"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.codescan.io/",
+        "source": null,
+        "description": "Code Quality and Security for Salesforce Developers. Made exclusively for the Salesforce platform, CodeScan’s code analysis solutions provide you with total visibility into your code health.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CodeScene": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "clojure",
+            "dart",
+            "elixir",
+            "erlang",
+            "go",
+            "groovy",
+            "java",
+            "javascript",
+            "kotlin",
+            "perl",
+            "php",
+            "powershell",
+            "python",
+            "ruby",
+            "scala",
+            "swift",
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://codescene.com",
+        "source": null,
+        "description": "CodeScene is a quality visualization tool for software. Prioritize technical debt, detect delivery risks, and measure organizational aspects. Fully automated.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "CodeScene Introduction - short video with the essentials of CodeScene",
+                "url": "https://www.youtube.com/watch?v=4Mwv-Swxo84"
+            },
+            {
+                "title": "Augmented Code Analysis with CodeScene",
+                "url": "https://www.youtube.com/watch?v=c2lqk98bC00"
+            },
+            {
+                "title": "Beyond code: interview with Adam Tornhill about CodeScene",
+                "url": "https://www.youtube.com/watch?v=tbCA2JiO_K8"
+            }
+        ],
+        "wrapper": null
+    },
+    "CodeSonar from GrammaTech": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.grammatech.com/products/codesonar",
+        "source": null,
+        "description": "Advanced, whole program, deep path, static analysis of C, C++, Java and C# with easy-to-understand explanations and code and path visualization.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Codeac": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go",
+            "java",
+            "javascript",
+            "php",
+            "python",
+            "ruby",
+            "typescript"
+        ],
+        "other": [
+            "container",
+            "ci"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.codeac.io/?ref=awesome-static-analysis",
+        "source": null,
+        "description": "Automated code review tool integrates with GitHub, Bitbucket and GitLab (even self-hosted). Available for JavaScript, TypeScript, Python, Ruby, Go, PHP, Java, Docker, and more. (open-source free)",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Codelyzer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://codelyzer.com",
+        "source": "https://github.com/mgechev/codelyzer",
+        "description": "A set of tslint rules for static code analysis of Angular 2 TypeScript projects.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "Codepeer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ada"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.adacore.com/codepeer",
+        "source": null,
+        "description": "Detects run-time and logic errors.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "What's New in CodePeer 19",
+                "url": "https://www.youtube.com/watch?v=8837TUpLLMo"
+            }
+        ],
+        "wrapper": null
+    },
+    "Coderrect": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "fortran"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://coderrect.com/",
+        "source": null,
+        "description": "Advanced static analyzer for multi-threaded software. Supports OpenMP, Pthreads, std::thread, and GPU/CUDA.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Detecting Data Races in Pthreads",
+                "url": "https://www.youtube.com/watch?v=YgkQ6moJH94"
+            },
+            {
+                "title": "Case Study: Redis Benchmark",
+                "url": "https://www.youtube.com/watch?v=sWvu7f-hhWc"
+            },
+            {
+                "title": "Discussion on Reddit",
+                "url": "https://www.reddit.com/r/cpp/comments/l7z6s9/a_fast_static_analysis_tool_for_detecting_race/"
+            }
+        ],
+        "wrapper": null
+    },
+    "Codiga": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "apex",
+            "c",
+            "cpp",
+            "go",
+            "java",
+            "javascript",
+            "kotlin",
+            "php",
+            "python",
+            "ruby",
+            "scala",
+            "typescript"
+        ],
+        "other": [
+            "ci",
+            "dockerfile"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.codiga.io",
+        "source": null,
+        "description": "Automated Code Reviews and Technical Debt management platform that supports 12+ languages.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "CogniCrypt": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "Eclipse Public License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.eclipse.org/cognicrypt",
+        "source": "https://github.com/eclipse-cognicrypt/CogniCrypt",
+        "description": "Checks Java source and byte code for incorrect uses of cryptographic APIs.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Tutorial: CogniCrypt basics, and how to integrate your own Crypto APIs into CognICrypt",
+                "url": "https://www.youtube.com/watch?v=vOZKN8yQcAY"
+            }
+        ],
+        "wrapper": null
+    },
+    "Corrode": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/jameysharp/corrode",
+        "source": "https://github.com/jameysharp/corrode",
+        "description": "Semi-automatic translation from C to Rust. Could reveal bugs in the original implementation by showing Rust compiler warnings and errors. Superseded by C2Rust.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "Coverity": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "fortran",
+            "java",
+            "javascript",
+            "php",
+            "python",
+            "scala",
+            "typescript",
+            "vbnet"
+        ],
+        "other": [
+            "rails",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.synopsys.com/software-integrity/security-testing/static-analysis-sast.html",
+        "source": null,
+        "description": "Synopsys Coverity supports 20 languages and over 70 frameworks including Ruby on rails, Scala, PHP, Python, JavaScript, TypeScript, Java, Fortran, C, C++, C#, VB.NET.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Checkmarx - Source Code Analysis Made Easy 2017",
+                "url": "https://www.youtube.com/watch?v=zo1pCl6yQ34"
+            }
+        ],
+        "wrapper": null
+    },
+    "CppDepend": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.cppdepend.com",
+        "source": null,
+        "description": "Measure, query and visualize your code and avoid unexpected issues, technical debt and complexity.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "D-scanner": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "dlang"
+        ],
+        "other": [],
+        "licenses": [
+            "Boost Software License 1.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/dlang-community/D-Scanner",
+        "source": "https://github.com/dlang-community/D-Scanner",
+        "description": "D-Scanner is a tool for analyzing D source code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Dart Code Metrics": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "dart"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pub.dev/packages/dart_code_metrics",
+        "source": "https://github.com/dart-code-checker/dart-code-metrics",
+        "description": "Additional linter for Dart. Reports code metrics, checks for anti-patterns and provides additional rules for Dart analyzer.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Datree": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement",
+            "container",
+            "kubernetes",
+            "security"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://datree.io/",
+        "source": "https://github.com/datreeio/datree",
+        "description": "A CLI tool to prevent Kubernetes misconfigurations by ensuring that manifests and Helm charts follow best practices as well as your organization’s policies",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "DeepCode": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "java",
+            "javascript",
+            "python",
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.deepcode.ai",
+        "source": null,
+        "description": "DeepCode finds bugs, security vulnerabilities, performance and API issues based on AI. DeepCode's speed of analysis allow us to analyse your code in real time and deliver results when you hit the save button in your IDE. Supported languages are Java, C/C++, JavaScript, Python, and TypeScript. Integrations with GitHub, BitBucket and Gitlab.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Intro to DeepCode",
+                "url": "https://www.youtube.com/watch?v=5ThvYN3nWcg"
+            },
+            {
+                "title": "How DeepCode addresses False Positives",
+                "url": "https://www.youtube.com/watch?v=d-fvZ83O_es"
+            }
+        ],
+        "wrapper": null
+    },
+    "DeepScan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://deepscan.io",
+        "source": null,
+        "description": "An analyzer for JavaScript which targets runtime errors and quality issues rather than coding conventions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "DeepSource": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go",
+            "javascript",
+            "python",
+            "ruby",
+            "sql"
+        ],
+        "other": [
+            "configmanagement",
+            "container"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://deepsource.io",
+        "source": null,
+        "description": "In-depth static analysis to find issues in verticals of bug risks, security, anti-patterns, performance, documentation and style. Native integrations with GitHub, GitLab and Bitbucket. Less than 5% false positives.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Depends": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "java",
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/multilang-depends/depends",
+        "source": "https://github.com/multilang-depends/depends",
+        "description": "Analyses the comprehensive dependencies of code elements for Java, C/C++, Ruby.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "DesignPatternDetector": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Halleck45/DesignPatternDetector",
+        "source": "https://github.com/Halleck45/DesignPatternDetector",
+        "description": "Detection of design patterns in PHP code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Designite": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.designite-tools.com",
+        "source": null,
+        "description": "Designite supports detection of various architecture, design, and implementation smells, computation of various code quality metrics, and trend analysis.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "DesigniteJava": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.designite-tools.com/designitejava",
+        "source": null,
+        "description": "DesigniteJava supports detection of various architecture, design, and implementation smells along with computation of various code quality metrics.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "DevSkim": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "asp",
+            "c",
+            "cpp",
+            "java",
+            "php",
+            "python",
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://github.com/microsoft/devskim",
+        "source": "https://github.com/microsoft/devskim",
+        "description": "Regex-based static analysis tool for Visual Studio, VS Code, and Sublime Text - C/C++, C#, PHP, ASP, Python, Ruby, Java, and others.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Dlint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/dlint-py/dlint",
+        "source": "https://github.com/dlint-py/dlint",
+        "description": "A tool for ensuring Python code is secure.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Docker Label Inspector": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "container"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/garethr/docker-label-inspector",
+        "source": "https://github.com/garethr/docker-label-inspector",
+        "description": "Lint and validate Dockerfile labels.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Doop": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "UPL"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://bitbucket.org/yanniss/doop",
+        "source": "https://bitbucket.org/yanniss/doop",
+        "description": "Doop is a declarative framework for static analysis of Java/Android programs, centered on pointer analysis algorithms. Doop provides a large variety of analyses and also the surrounding scaffolding to run an analysis end-to-end (fact generation, processing, statistics, etc.).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "DrNim": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "nim"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://nim-lang.org/docs/drnim.html",
+        "source": "https://nim-lang.org/docs/drnim.html",
+        "description": "DrNim combines the Nim frontend with the Z3 proof engine in order to allow verify / validate software written in Nim.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ERB Lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [
+            "erb",
+            "html"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Shopify/erb-lint",
+        "source": "https://github.com/Shopify/erb-lint",
+        "description": "Lint your ERB or HTML files",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ESBMC": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://esbmc.org",
+        "source": "https://github.com/esbmc/esbmc",
+        "description": "ESBMC is an open source, permissively licensed, context-bounded model checker based on satisfiability modulo theories for the verification of single- and multi-threaded C/C++ programs.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ESLint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "flow",
+            "javascript",
+            "jsx",
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/eslint/eslint",
+        "source": "https://github.com/eslint/eslint",
+        "description": "An extensible linter for JS, following the ECMAScript standard.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "VSCode ESLint, Prettier & Airbnb Style Guide Setup",
+                "url": "https://www.youtube.com/watch?v=SydnKbGc7W8"
+            }
+        ],
+        "wrapper": null
+    },
+    "EasyCodingStandard": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.tomasvotruba.com/blog/2017/05/03/combine-power-of-php-code-sniffer-and-php-cs-fixer-in-3-lines",
+        "source": "https://github.com/Symplify/EasyCodingStandard",
+        "description": "Combine [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) and [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Embold": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "go",
+            "java",
+            "javascript",
+            "kotlin",
+            "python",
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://embold.io",
+        "source": null,
+        "description": "Intelligent software analytics platform that identifies design issues, code issues, duplication and metrics. Supports Java, C, C++, C#, JavaScript, TypeScript, Python, Go, Kotlin and more.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Enlightn": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [
+            "laravel",
+            "security"
+        ],
+        "licenses": [
+            "LGPL-3.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.laravel-enlightn.com/",
+        "source": "https://github.com/enlightn/enlightn",
+        "description": "A static and dynamic analysis tool for Laravel applications that provides recommendations to improve the performance, security and code reliability of Laravel apps. Contains 120 automated checks.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Error-prone": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://errorprone.info",
+        "source": "https://github.com/google/error-prone",
+        "description": "Catch common Java mistakes as compile-time errors.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Esprima": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 2-Clause \"Simplified\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://esprima.org",
+        "source": "https://github.com/jquery/esprima",
+        "description": "ECMAScript parsing infrastructure for multipurpose analysis.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "FSharpLint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "fsharp"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://fsprojects.github.io/FSharpLint",
+        "source": "https://github.com/fsprojects/FSharpLint",
+        "description": "Lint tool for F#.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Fasterer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/DamirSvrtan/fasterer",
+        "source": "https://github.com/DamirSvrtan/fasterer",
+        "description": "Common Ruby idioms checker.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Find Security Bugs": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "groovy",
+            "java",
+            "kotlin",
+            "scala"
+        ],
+        "other": [],
+        "licenses": [
+            "LGPL-3.0-only"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://find-sec-bugs.github.io",
+        "source": "https://github.com/find-sec-bugs/find-sec-bugs",
+        "description": "The SpotBugs plugin for security audits of Java web applications and Android applications. (Also work with Kotlin, Groovy and Scala projects)",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Fix Insight": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "delphi"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.tmssoftware.com/site/fixinsight.asp",
+        "source": "https://www.tmssoftware.com/site/fixinsight.asp",
+        "description": "A free IDE Plugin for static code analysis. A _Pro_ edition includes a command line tool for automation purposes.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "FlowDroid": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "mobile"
+        ],
+        "licenses": [
+            "GNU Lesser General Public License v2.1"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/secure-software-engineering/FlowDroid",
+        "source": "https://github.com/secure-software-engineering/FlowDroid",
+        "description": "Static taint analysis tool for Android applications.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Fortify": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "abap",
+            "actionscript",
+            "apex",
+            "aspnet",
+            "c",
+            "csharp",
+            "cpp",
+            "cobol",
+            "coldfusion",
+            "java",
+            "javascript",
+            "jsp",
+            "objectivec",
+            "php",
+            "plsql",
+            "python",
+            "ruby",
+            "scala",
+            "swift",
+            "tsql",
+            "vbscript",
+            "vbasic",
+            "vbnet"
+        ],
+        "other": [
+            "html",
+            "security",
+            "xml"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://software.microfocus.com/en-us/products/static-code-analysis-sast/overview",
+        "source": null,
+        "description": "A commercial static analysis platform that supports the scanning of C/C++, C#, VB.NET, VB6, ABAP/BSP, ActionScript, Apex, ASP.NET, Classic ASP, VB Script, Cobol, ColdFusion, HTML, Java, JS, JSP, MXML/Flex, Objective-C, PHP, PL/SQL, T-SQL, Python (2.6, 2.7), Ruby (1.9.3), Swift, Scala, VB, and XML.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Visual Studio - real-time security with Fortify Security Assistant (2018)",
+                "url": "https://www.youtube.com/watch?v=7CfeUXtDlwQ"
+            }
+        ],
+        "wrapper": null
+    },
+    "Frama-C": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU Lesser General Public License v2.1"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://frama-c.com",
+        "source": "http://frama-c.com/download.html",
+        "description": "A sound and extensible static analyzer for C code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Frink": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "tcl"
+        ],
+        "other": [],
+        "licenses": [
+            "unknown"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://catless.ncl.ac.uk/Programs/Frink",
+        "source": "http://catless.ncl.ac.uk/Programs/Frink",
+        "description": "A Tcl formatting and static check program (can prettify the program, minimise, obfuscate or just sanity check it).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Fukuzatsu": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/CoralineAda/fukuzatsu",
+        "source": "https://github.com/CoralineAda/fukuzatsu",
+        "description": "A tool for measuring code complexity in Ruby class files. Its analysis generates scores based on cyclomatic complexity algorithms with no added \"opinions\".",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Gendarme": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.mono-project.com/docs/tools+libraries/tools/gendarme",
+        "source": "https://github.com/mono/mono-tools",
+        "description": "Gendarme inspects programs and libraries that contain code in ECMA CIL format (Mono and .NET).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Ghidra": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://ghidra-sre.org",
+        "source": "https://github.com/NationalSecurityAgency/ghidra",
+        "description": "A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Ghidra Installation Guide",
+                "url": "https://ghidra-sre.org/InstallationGuide.html"
+            }
+        ],
+        "wrapper": null
+    },
+    "Gitleaks": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "security"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/zricethezav/gitleaks",
+        "source": "https://github.com/zricethezav/gitleaks",
+        "description": "A SAST tool for detecting hardcoded secrets like passwords, api keys, and tokens in git repos.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Go Meta Linter": {
+        "categories": [
+            "meta"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [
+            "meta"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/alecthomas/gometalinter",
+        "source": "https://github.com/alecthomas/gometalinter",
+        "description": "Concurrently run Go lint tools and normalise their output. Use `golangci-lint` for new projects.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "GolangCI-Lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://golangci-lint.run",
+        "source": "https://github.com/golangci/golangci-lint",
+        "description": "Alternative to `Go Meta Linter`: GolangCI-Lint is a linters aggregator.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "GopherCon 2019: Denis Isaev (author of golangci-lint) - Go Linters: Myths and Best Practices",
+                "url": "https://www.youtube.com/watch?v=1U-Gzz4TYP0"
+            }
+        ],
+        "wrapper": null
+    },
+    "Goodcheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "java",
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://sider.github.io/goodcheck",
+        "source": "https://github.com/sideci/goodcheck",
+        "description": "Regexp based customizable linter.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "GraphMyCSS.com": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "css"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://graphmycss.com",
+        "source": "https://github.com/TheJaredWilcurt/itcss-specificity-graph",
+        "description": "CSS Specificity Graph Generator.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "GrumPHP": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/phpro/grumphp",
+        "source": "https://github.com/phpro/grumphp",
+        "description": "Checks code on every commit.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "HCL AppScan Source": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "asp",
+            "aspnet",
+            "c",
+            "csharp",
+            "cpp",
+            "cobol",
+            "coldfusion",
+            "java",
+            "javascript",
+            "jsp",
+            "perl",
+            "php",
+            "plsql",
+            "tsql",
+            "vbscript",
+            "vbasic",
+            "vbnet"
+        ],
+        "other": [
+            "mobile",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.hcltechsw.com/products/appscan",
+        "source": null,
+        "description": "Commercial Static Code Analysis.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Introducing HCL AppScan Standard",
+                "url": "https://www.youtube.com/watch?v=TmYY67w18RI"
+            }
+        ],
+        "wrapper": null
+    },
+    "HLint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "haskell"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/ndmitchell/hlint",
+        "source": "https://github.com/ndmitchell/hlint",
+        "description": "HLint is a tool for suggesting possible improvements to Haskell code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "HTML Inspector": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "html"
+        ],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/philipwalton/html-inspector",
+        "source": "https://github.com/philipwalton/html-inspector",
+        "description": "HTML Inspector is a code quality tool to help you and your team write better markup.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "HTML Tidy": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "html"
+        ],
+        "licenses": [
+            "Custom"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.html-tidy.org",
+        "source": "https://github.com/htacg/tidy-html5",
+        "description": "Corrects and cleans up HTML and XML documents by fixing markup errors and upgrading legacy code to modern standards.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "HTML-Validate": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "html",
+            "vue"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "ide-plugin",
+            "cli"
+        ],
+        "homepage": "https://html-validate.org/",
+        "source": "https://gitlab.com/html-validate/html-validate",
+        "description": "Offline HTML5 validator.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "HTMLHint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "html"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://htmlhint.com",
+        "source": "https://github.com/yaniswang/HTMLHint",
+        "description": "A Static Code Analysis Tool for HTML.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Haskell Dockerfile Linter": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "container"
+        ],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/lukasmartinelli/hadolint",
+        "source": "https://github.com/lukasmartinelli/hadolint",
+        "description": "A smarter Dockerfile linter that helps you build best practice Docker images.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Haxe Checkstyle": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "haxe"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://haxecheckstyle.github.io/docs/haxe-checkstyle/home.html",
+        "source": "https://github.com/HaxeCheckstyle/haxe-checkstyle",
+        "description": "A static analysis tool to help developers write Haxe code that adheres to a coding standard.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Helix QAC": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.perforce.com/products/helix-qac",
+        "source": null,
+        "description": "Enterprise-grade static analysis for embedded software. Supports MISRA, CERT, and AUTOSAR coding standards.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Code with Confidence - Helix QAC",
+                "url": "https://www.youtube.com/watch?v=HHaBnZx2fGY"
+            },
+            {
+                "title": "How to Apply AUTOSAR Guidelines With Helix QAC",
+                "url": "https://www.youtube.com/watch?v=XFvZ_hh6LCo"
+            }
+        ],
+        "wrapper": null
+    },
+    "Hopper": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "groovy",
+            "java",
+            "kotlin",
+            "scala"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/cuplv/hopper",
+        "source": "https://github.com/cuplv/hopper",
+        "description": "A static analysis tool written in scala for languages that run on JVM.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "Hound CI": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "coffeescript",
+            "go",
+            "javascript",
+            "ruby",
+            "swift"
+        ],
+        "other": [
+            "css",
+            "haml"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://houndci.com",
+        "source": "https://github.com/houndci/hound",
+        "description": "Comments on style violations in GitHub pull requests. Supports Coffeescript, Go, HAML, JavaScript, Ruby, SCSS and Swift.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "HuntBugs": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/amaembo/huntbugs",
+        "source": "https://github.com/amaembo/huntbugs",
+        "description": "Bytecode static analyzer tool based on Procyon Compiler Tools aimed to supersede FindBugs.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "IDA Free": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.hex-rays.com/products/ida/support/download_freeware",
+        "source": null,
+        "description": "Binary code analysis tool.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "IKOS": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/nasa-sw-vnv/ikos",
+        "source": "https://github.com/nasa-sw-vnv/ikos",
+        "description": "A sound static analyzer for C/C++ code based on LLVM.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Icarus Verilog": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "verilog"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/steveicarus/iverilog",
+        "source": "http://iverilog.icarus.com/",
+        "description": "A Verilog simulation and synthesis tool that operates by compiling source code written in IEEE-1364 Verilog into some target format",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Infer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "java",
+            "objectivec"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://fbinfer.com",
+        "source": "https://github.com/facebook/infer",
+        "description": "A static analyzer for Java, C and Objective-C",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Infer#": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/microsoft/infersharp",
+        "source": "https://github.com/microsoft/infersharp",
+        "description": "InferSharp (also referred to as Infer#) is an interprocedural and  scalable static code analyzer for C#. Via the capabilities of Facebook's Infer,  this tool detects null pointer dereferences and resource leaks.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "InsiderSec": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "dotnet",
+            "csharp",
+            "java",
+            "javascript",
+            "kotlin",
+            "swift"
+        ],
+        "other": [
+            "mobile",
+            "nodejs",
+            "security"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://insidersec.io",
+        "source": "https://github.com/insidersec/insider",
+        "description": "A open source Static Application Security Testing tool (SAST) written in GoLang for Java (Maven and Android), Kotlin (Android), Swift (iOS), .NET Full Framework, C# and Javascript (Node.js).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "InspectorTiger": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/thg-consulting/it",
+        "source": "https://github.com/thg-consulting/it",
+        "description": "IT, Inspector Tiger, is a modern python code review tool / framework. It comes with bunch of pre-defined handlers which warns you about improvements and possible bugs. Beside these handlers, you can write your own or use community ones.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "IntelliJ IDEA": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://www.jetbrains.com/idea",
+        "source": null,
+        "description": "Comes bundled with a lot of inspections for Java and Kotlin and includes tools for refactoring, formatting and more.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "JArchitect": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.jarchitect.com",
+        "source": null,
+        "description": "Measure, query and visualize your code and avoid unexpected issues, technical debt and complexity.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "JBMC": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD-4-Clause-UC (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.cprover.org/jbmc",
+        "source": "https://github.com/peterschrammel/cbmc/releases/tag/jbmc-5.8-cav18",
+        "description": "Bounded model-checker for Java (bytecode), verifies user-defined assertions, standard assertions, several coverage metric analyses.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "JEB Decompiler": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.pnfsoftware.com/",
+        "source": null,
+        "description": "Decompile and debug binary code. Break down and analyze document files. Android Dalvik, MIPS, ARM, Intel x86, Java, WebAssembly & Ethereum Decompilers.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "JSLint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "Llvm release license"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/douglascrockford/JSLint",
+        "source": "https://github.com/douglascrockford/JSLint",
+        "description": "The JavaScript Code Quality Tool.",
+        "discussion": "https://github.com/analysis-tools-dev/static-analysis/issues/223",
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "JSPrime": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://dpnishant.github.io/jsprime",
+        "source": "https://github.com/dpnishant/jsprime",
+        "description": "Static security analysis tool.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "Jakstab": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "GNU General Public License v2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/jkinder/jakstab",
+        "source": "https://github.com/jkinder/jakstab",
+        "description": "Jakstab is an Abstract Interpretation-based, integrated disassembly and static analysis framework for designing analyses on executables and recovering reliable control flow graphs.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Joern": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://joern.io",
+        "source": "https://github.com/ShiftLeftSecurity/joern",
+        "description": "Open-source code analysis platform for C/C++ based on code property graphs",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Kiuwan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "go",
+            "java",
+            "javascript",
+            "kotlin",
+            "php",
+            "python",
+            "scala",
+            "swift"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.kiuwan.com/code-security-sast",
+        "source": null,
+        "description": "Identify and remediate cyber threats in a blazingly fast, collaborative environment, with seamless integration in your SDLC. Python, C\\C++, Java, C#, PHP and more.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Klocwork": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.perforce.com/products/klocwork",
+        "source": null,
+        "description": "Quality and Security Static analysis for C/C++, Java and C#.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "KubeLinter": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "container"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/stackrox/kube-linter",
+        "source": "https://github.com/stackrox/kube-linter",
+        "description": "KubeLinter is a static analysis tool that checks Kubernetes YAML files and Helm charts to ensure the applications represented in them adhere to best practices.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "KubeLinter: An open source linter for Kubernetes, from StackRox",
+                "url": "https://www.youtube.com/watch?v=KWX0sWojV_0"
+            },
+            {
+                "title": "Announcement blog post",
+                "url": "https://www.stackrox.com/post/2020/10/introducing-kubelinter-an-open-source-linter-for-kubernetes"
+            }
+        ],
+        "wrapper": null
+    },
+    "LDRA": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://ldra.com",
+        "source": null,
+        "description": "A tool suite including static analysis (TBVISION) to various standards including MISRA C & C++, JSF++ AV, CWE, CERT C, CERT C++ & Custom Rules.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "LGTM": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "java",
+            "php"
+        ],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://lgtm.com/",
+        "source": null,
+        "description": "Find security vulnerabilities, variants, and critical code quality issues using queries over source code. Automatic PR code review; free for open source. Formerly semmle.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Welcoming Semmle to GitHub",
+                "url": "https://github.blog/2019-09-18-github-welcomes-semmle/"
+            }
+        ],
+        "wrapper": null
+    },
+    "LGTM.com": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "go",
+            "java",
+            "javascript",
+            "python",
+            "typescript"
+        ],
+        "other": [
+            "ci",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://lgtm.com",
+        "source": null,
+        "description": "Deep code analysis for GitHub and Bitbucket to find security vulnerabilities and critical code quality issues (using Semmle QL). Automatic code review for pull requests; free for public repositories.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "LibVCS4j": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "support"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/uni-bremen-agst/libvcs4j",
+        "source": "https://github.com/uni-bremen-agst/libvcs4j",
+        "description": "A Java library that allows existing tools to analyse the evolution of software systems by providing a common API for different version control systems and issue trackers.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Linter for dart": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "dart"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://dart-lang.github.io/linter",
+        "source": "https://github.com/dart-lang/linter",
+        "description": "Style linter for Dart.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Liquid Haskell": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "haskell"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://ucsd-progsys.github.io/liquidhaskell-blog/",
+        "source": "https://github.com/ucsd-progsys/liquidhaskell",
+        "description": "Liquid Haskell is a refinement type checker for Haskell programs.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Luanalysis": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "lua"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://plugins.jetbrains.com/plugin/14698-luanalysis",
+        "source": "https://github.com/Benjamin-Dobell/IntelliJ-Luanalysis",
+        "description": "An IDE for statically typed Lua development.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "MIRAI": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/facebookexperimental/MIRAI",
+        "source": "https://github.com/facebookexperimental/MIRAI",
+        "description": "And abstract interpreter operating on Rust's mid-level intermediate language, and providing warnings based on taint analysis.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Manalyze": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/JusticeRage/Manalyze",
+        "source": "https://github.com/JusticeRage/Manalyze",
+        "description": "A static analyzer, which checks portable executables for malicious content.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Mega-Linter": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "dotnet",
+            "apex",
+            "c",
+            "csharp",
+            "cpp",
+            "clojure",
+            "coffeescript",
+            "dart",
+            "go",
+            "groovy",
+            "java",
+            "javascript",
+            "jsx",
+            "kotlin",
+            "lwc",
+            "lua",
+            "perl",
+            "php",
+            "powershell",
+            "python",
+            "r",
+            "raku",
+            "ruby",
+            "rust",
+            "scala",
+            "shell",
+            "sql",
+            "typescript",
+            "vbnet"
+        ],
+        "other": [
+            "editorconfig",
+            "dotenv",
+            "ansible",
+            "arm",
+            "cloudformation",
+            "configfile",
+            "configmanagement",
+            "container",
+            "ci",
+            "css",
+            "dockerfile",
+            "formatter",
+            "gherkin",
+            "graphql",
+            "html",
+            "json",
+            "jsonschema",
+            "kubernetes",
+            "latex",
+            "markdown",
+            "nodejs",
+            "protobuf",
+            "puppet",
+            "rst",
+            "snakemake",
+            "terraform",
+            "vue",
+            "writing",
+            "xml",
+            "yaml"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://nvuillam.github.io/mega-linter/",
+        "source": "https://github.com/nvuillam/mega-linter",
+        "description": "Mega-Linter can handle any type of project thanks to its 70+ embedded Linters,\n its advanced reporting, runnable on any CI system or locally,\n with assisted installation and configuration, able to apply formatting and fixes",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "How Mega-linter works",
+                "url": "https://nvuillam.github.io/mega-linter/frequently-asked-questions/"
+            },
+            {
+                "title": "List of Mega-Linter supported languages, formats and tooling formats",
+                "url": "https://nvuillam.github.io/mega-linter/supported-linters/"
+            },
+            {
+                "title": "Assisted installation guide",
+                "url": "https://nvuillam.github.io/mega-linter/installation/"
+            },
+            {
+                "title": "Assisted configuration guide",
+                "url": "https://nvuillam.github.io/mega-linter/configuration/"
+            }
+        ],
+        "wrapper": null
+    },
+    "Misspelled Words In Context": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "writing"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://jwilk.net/software/mwic",
+        "source": "https://github.com/jwilk/mwic",
+        "description": "A spell-checker that groups possible misspellings and shows them in their contexts.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Mondrian": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "CC-BY-SA-3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://trismegiste.github.io/Mondrian",
+        "source": "https://github.com/Trismegiste/Mondrian",
+        "description": "A set of static analysis and refactoring tools which use graph theory.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "MythX": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "smart-contracts"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "ide-plugin",
+            "cli",
+            "service"
+        ],
+        "homepage": "https://mythx.io",
+        "source": null,
+        "description": "MythX is an easy to use analysis platform which integrates several analysis methods like fuzzing, symbolic execution and static analysis to find vulnerabilities with high precision. It can be integrated with toolchains like Remix or VSCode or called from the command-line.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "What is MythX?",
+                "url": "https://www.youtube.com/watch?v=N-dAuqNztjA"
+            }
+        ],
+        "wrapper": null
+    },
+    "NDepend": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.ndepend.com",
+        "source": null,
+        "description": "Measure, query and visualize your code and avoid unexpected issues, technical debt and complexity.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Nagelfar": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "tcl"
+        ],
+        "other": [],
+        "licenses": [
+            "GPL v2"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://sourceforge.net/projects/nagelfar",
+        "source": "https://sourceforge.net/p/nagelfar/code/ci/master/tree",
+        "description": "A static syntax checker for Tcl.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Nauz File Detector": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/horsicq/Nauz-File-Detector",
+        "source": "https://github.com/horsicq/Nauz-File-Detector",
+        "description": "Static Linker/Compiler/Tool detector for Windows, Linux and MacOS.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Nitpick CI": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://nitpick-ci.com",
+        "source": null,
+        "description": "Automated PHP code review.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "NodeJSScan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [
+            "nodejs",
+            "security"
+        ],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli",
+            "service"
+        ],
+        "homepage": "https://opensecurity.in",
+        "source": "https://github.com/ajinabraham/NodeJsScan",
+        "description": "A static security code scanner for Node.js applications powered by libsast and semgrep that builds on the njsscan cli tool. It features a UI with various dashboards about an application's security status.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Nu Html Checker": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "css",
+            "html"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://validator.github.io/validator/",
+        "source": "https://github.com/validator/validator",
+        "description": "Helps you catch problems in your HTML/CSS/SVG",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "NullAway": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/uber/NullAway",
+        "source": "https://github.com/uber/NullAway",
+        "description": "Type-based null-pointer checker with low build-time overhead; an [Error Prone](http://errorprone.info/) plugin.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "OWASP Dependency Check": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://owasp.org/www-project-dependency-check",
+        "source": "https://github.com/jeremylong/DependencyCheck",
+        "description": "Checks dependencies for known, publicly disclosed, vulnerabilities.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Offensive 360": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "dotnet",
+            "asp",
+            "csharp",
+            "java",
+            "javascript",
+            "jsx",
+            "php",
+            "typescript",
+            "vbscript",
+            "vbasic",
+            "vbnet"
+        ],
+        "other": [
+            "container",
+            "html",
+            "mobile",
+            "nodejs",
+            "phonegap",
+            "security",
+            "xml"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "web"
+        ],
+        "homepage": "https://offensive360.com/",
+        "source": null,
+        "description": "Commercial Static Code Analysis system doesn't require building the source code or pre-compilation.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "OpenSCAP": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "container"
+        ],
+        "licenses": [
+            "LGPL-2.1 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.open-scap.org/",
+        "source": "https://github.com/OpenSCAP/openscap",
+        "description": "Suite of automated audit tools to examine the configuration and  known vulnerabilities following the NIST-certified Security  Content Automation Protocol (SCAP).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Oversecured": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "mobile",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://oversecured.com",
+        "source": null,
+        "description": "Enterprise vulnerability scanner for Android and iOS apps. It allows app owners and developers to secure each new version of a mobile app by integrating Oversecured into the development process.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PC-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.gimpel.com",
+        "source": null,
+        "description": "Static analysis for C/C++. Runs natively under Windows/Linux/MacOS. Analyzes code for virtually any platform, supporting C11/C18 and C++17.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PHP Architecture Tester": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/carlosas/phpat",
+        "source": "https://github.com/carlosas/phpat",
+        "description": "Easy to use architecture testing tool for PHP.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PHP Assumptions": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/rskuipers/php-assumptions",
+        "source": "https://github.com/rskuipers/php-assumptions",
+        "description": "Checks for weak assumptions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PHP Coding Standards Fixer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://cs.symfony.com",
+        "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer",
+        "description": "Fixes your code according to standards like PSR-1, PSR-2, and the Symfony standard.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PHP Insights": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://phpinsights.com",
+        "source": "https://github.com/nunomaduro/phpinsights",
+        "description": "Instant PHP quality checks from your console. Analysis of code quality and coding style as well as overview of code architecture and its complexity.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PHP Refactoring Browser": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://qafoolabs.github.io/php-refactoring-browser",
+        "source": "https://github.com/QafooLabs/php-refactoring-browser",
+        "description": "Refactoring helper.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PHP Semantic Versioning Checker": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/tomzx/php-semver-checker",
+        "source": "https://github.com/tomzx/php-semver-checker",
+        "description": "Suggests a next version according to semantic versioning.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PHP-Parser": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/nikic/PHP-Parser",
+        "source": "https://github.com/nikic/PHP-Parser",
+        "description": "A PHP parser written in PHP.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PHP-Token-Reflection": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Andrewsville/PHP-Token-Reflection",
+        "source": "https://github.com/Andrewsville/PHP-Token-Reflection",
+        "description": "Library emulating the PHP internal reflection.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PHPMD": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://phpmd.org",
+        "source": "https://github.com/phpmd/phpmd",
+        "description": "Finds possible bugs in your code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PHPQA": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://edgedesigncz.github.io/phpqa",
+        "source": "https://github.com/EdgedesignCZ/phpqa",
+        "description": "A tool for running QA tools (phploc, phpcpd, phpcs, pdepend, phpmd, phpmetrics).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PHPStan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://phpstan.org",
+        "source": "https://github.com/phpstan/phpstan",
+        "description": "PHP Static Analysis Tool - discover bugs in your code without running it!",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PHP_CodeSniffer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pear.php.net/package/PHP_CodeSniffer",
+        "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+        "description": "Detects violations of a defined set of coding standards.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PMD": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "apex",
+            "java",
+            "javascript",
+            "plsql",
+            "scala",
+            "visualforce"
+        ],
+        "other": [
+            "xml"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pmd.github.io",
+        "source": "https://github.com/pmd/pmd",
+        "description": "A source code analyzer for Java, Salesforce Apex, Javascript, PLSQL, XML, XSL and others.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PT Application Inspector": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.ptsecurity.com",
+        "source": null,
+        "description": "Identifies code flaws and detects vulnerabilities to prevent web attacks. Demonstrates remote code execution by presenting possible exploits.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Introduction video",
+                "url": "https://www.youtube.com/watch?v=gtFH6tV2dlM"
+            }
+        ],
+        "wrapper": null
+    },
+    "PT.PM": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp",
+            "java",
+            "javascript",
+            "php",
+            "plsql",
+            "tsql"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/PositiveTechnologies/PT.PM",
+        "source": "https://github.com/PositiveTechnologies/PT.PM",
+        "description": "An engine for searching patterns in the source code, based on Unified AST or UST. At present time C#, Java, PHP, PL/SQL, T-SQL, and JavaScript are supported. Patterns can be described within the code or using a DSL.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "PVS-Studio": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://pvs-studio.com",
+        "source": null,
+        "description": "A ([conditionally free](https://pvs-studio.com/en/order/open-source-license) for FOSS and individual developers) static analysis of C, C++, C# and Java code. For advertising purposes [you can propose a large FOSS project for analysis by PVS employees](https://github.com/viva64/pvs-studio-check-list). Supports CWE mapping, MISRA and CERT coding standards.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "PVS-Studio is now in Compiler Explorer!",
+                "url": "https://www.youtube.com/watch?v=hw5npZqB3b8"
+            },
+            {
+                "title": "PVS-Studio in 2019",
+                "url": "https://www.youtube.com/watch?v=FkfMGqxIR-I"
+            },
+            {
+                "title": "Static Analysis in C++ (mostly about PVS-Studio)",
+                "url": "https://www.youtube.com/watch?v=vYW6TOwFK2M"
+            }
+        ],
+        "wrapper": null
+    },
+    "Parker": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "css"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/katiefenn/parker",
+        "source": "https://github.com/katiefenn/parker",
+        "description": "Stylesheet analysis tool.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Parse": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/psecio/parse",
+        "source": "https://github.com/psecio/parse",
+        "description": "A Static Security Scanner.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Pascal Analyzer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "delphi"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://peganza.com/products_pal.html",
+        "source": null,
+        "description": "A static code analysis tool with numerous reports. A free _Lite_ version is available with limited reporting.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Pascal Expert": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "delphi"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://peganza.com/products_pex.html",
+        "source": null,
+        "description": "IDE plugin for code analysis. Includes a subset of Pascal Analyzer reporting capabilities and is available for Delphi versions 2007 and later.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Perl::Critic": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "perl"
+        ],
+        "other": [],
+        "licenses": [
+            "GPL v2"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://metacpan.org/pod/Perl::Critic",
+        "source": "https://metacpan.org/release/Perl-Critic/source/lib/Perl/Critic.pm",
+        "description": "Critique Perl source code for best-practices.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Phasar": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://phasar.org",
+        "source": "https://github.com/secure-software-engineering/phasar",
+        "description": "A LLVM-based static analysis framework which comes with a taint and type state analysis.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Php Inspections (EA Extended)": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://plugins.jetbrains.com/plugin/7622-php-inspections-ea-extended-",
+        "source": "https://github.com/kalessil/phpinspectionsea",
+        "description": "A Static Code Analyzer for PHP.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PhpDependencyAnalysis": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://mamuz.github.io/PhpDependencyAnalysis",
+        "source": "https://github.com/mamuz/PhpDependencyAnalysis",
+        "description": "Builds a dependency graph for a project.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PhpDeprecationDetector": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD-3-Clause"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/wapmorgan/PhpDeprecationDetector",
+        "source": "https://github.com/wapmorgan/PhpDeprecationDetector",
+        "description": "Analyzer of PHP code to search issues with deprecated functionality in newer interpreter versions.  It finds removed objects (functions, variables, constants and ini-directives),  deprecated functions functionality, and usage of forbidden names or tricks (e.g. reserved identifiers in newer versions).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PhpMetrics": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.phpmetrics.org",
+        "source": "https://github.com/phpmetrics/PhpMetrics",
+        "description": "Calculates and visualizes various code quality metrics.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Polymer-analyzer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [
+            "html"
+        ],
+        "licenses": [
+            "BSD-3-Clause (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Polymer/tools/tree/master/packages/analyzer",
+        "source": "https://github.com/Polymer/tools/tree/master/packages/analyzer",
+        "description": "A static analysis framework for Web Components.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Polyspace Bug Finder": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.mathworks.com/products/polyspace-bug-finder.html",
+        "source": null,
+        "description": "Identifies run-time errors, concurrency issues, security vulnerabilities, and other defects in C and C++ embedded software.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Polyspace Code Prover": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.mathworks.com/products/polyspace-code-prover.html",
+        "source": null,
+        "description": "Provide code verification that proves the absence of overflow, divide-by-zero, out-of-bounds array access, and certain other run-time errors in C and C++ source code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Polyspace for Ada": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ada"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.mathworks.com/products/polyspace-ada.html",
+        "source": null,
+        "description": "Provide code verification that proves the absence of overflow, divide-by-zero, out-of-bounds array access, and certain other run-time errors in source code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PostCSS": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "css"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://postcss.org",
+        "source": "https://github.com/postcss/postcss",
+        "description": "A tool for transforming styles with JS plugins. These plugins can lint your CSS, support variables and mixins, transpile future CSS syntax, inline images, and more.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Prettier": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "javascript",
+            "typescript"
+        ],
+        "other": [
+            "html"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://prettier.io",
+        "source": "https://github.com/prettier/prettier",
+        "description": "An opinionated code formatter.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Code Formatting with Prettier in Visual Studio Code",
+                "url": "https://www.youtube.com/watch?v=h3PJjP0nE98"
+            },
+            {
+                "title": "VSCode ESLint, Prettier & Airbnb Style Guide Setup",
+                "url": "https://www.youtube.com/watch?v=SydnKbGc7W8"
+            }
+        ],
+        "wrapper": null
+    },
+    "Primitive Erlang Security Tool (PEST)": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "erlang"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/okeuday/pest",
+        "source": "https://github.com/okeuday/pest",
+        "description": "A tool to do a basic scan of Erlang source code and report any function calls that may cause Erlang source code to be insecure.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Progpilot": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/designsecurity/progpilot",
+        "source": "https://github.com/designsecurity/progpilot",
+        "description": "A static analysis tool for security purposes.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Project Wallace CSS Analyzer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "css"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.projectwallace.com",
+        "source": "https://github.com/projectwallace/css-analyzer",
+        "description": "Analytics for CSS, part of [Project Wallace](https://www.projectwallace.com).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Pronto": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "elixir",
+            "java",
+            "javascript",
+            "php",
+            "ruby"
+        ],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/prontolabs/pronto",
+        "source": "https://github.com/prontolabs/pronto",
+        "description": "Quick automated code review of your changes. Supports more than 40 runners for various languages, including Clang, Elixir, JavaScript, PHP, Ruby and more.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Prusti": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.pm.inf.ethz.ch/research/prusti.html",
+        "source": "https://github.com/viperproject/prusti-dev",
+        "description": "A static verifier for Rust, based on the Viper verification infrastructure. By default Prusti verifies absence of panics by proving that statements such as unreachable!() and panic!() are unreachable.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Psalm": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://psalm.dev",
+        "source": "https://github.com/vimeo/psalm",
+        "description": "Static analysis tool for finding type errors in PHP applications.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PullRequest": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.pullrequest.com",
+        "source": null,
+        "description": "Code review as a service with built-in static analysis.  Increase velocity and reduce technical debt through quality code review by expert engineers backed by best-in-class automation.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Puma Scan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "Mozilla Public License 2.0"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://pumasecurity.io",
+        "source": "https://github.com/pumasecurity/puma-scan",
+        "description": "Puma Scan provides real time secure code analysis for common vulnerabilities (XSS, SQLi, CSRF, LDAPi, crypto, deserialization, etc.) as development teams write code in Visual Studio.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Puppet Lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/rodjek/puppet-lint",
+        "source": "https://github.com/rodjek/puppet-lint",
+        "description": "Check that your Puppet manifests conform to the style guide.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PyCodeQual": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://pycodequ.al",
+        "source": null,
+        "description": "PyCodeQual gives you insights into complexity and bug risks. It adds automatic reviews to your pull requests.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "PyT - Python Taint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/python-security/pyt",
+        "source": "https://github.com/python-security/pyt",
+        "description": "A static analysis tool for detecting security vulnerabilities in Python web applications.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "Pysa": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pyre-check.org/docs/pysa-basics.html",
+        "source": "https://github.com/facebook/pyre-check",
+        "description": "A tool based on Facebook's pyre-check to identify potential security issues in Python code identified with taint analysis.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Workshop: Graham Bleaney - Pysa to Identify Python Vulnerabilities - DEF CON 28SM AppSec Village",
+                "url": "https://www.youtube.com/watch?v=8I3zlvtpOww"
+            }
+        ],
+        "wrapper": null
+    },
+    "Qafoo Quality Analyzer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU Affero General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Qafoo/QualityAnalyzer",
+        "source": "https://github.com/Qafoo/QualityAnalyzer",
+        "description": "Visualizes metrics and source code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Qualys Container Security": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "container",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.qualys.com/apps/container-security",
+        "source": null,
+        "description": "Container native application protection to provide visibility and control of containerized applications.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "QuantifiedCode": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [
+            "ci",
+            "security"
+        ],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://github.com/quantifiedcode/quantifiedcode",
+        "source": "https://github.com/quantifiedcode/quantifiedcode",
+        "description": "Automated code review & repair. It helps you to keep track of issues and metrics in your software projects, and can be easily extended to support new types of analyses.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "Querly": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/soutaro/querly",
+        "source": "https://github.com/soutaro/querly",
+        "description": "Pattern Based Checking Tool for Ruby.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "RIPS": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java",
+            "php"
+        ],
+        "other": [
+            "nodejs"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.ripstech.com",
+        "source": null,
+        "description": "A static source code analyser for vulnerabilities in PHP scripts.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "RSLint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://rslint.org/",
+        "source": "https://github.com/RDambrosio016/RSLint",
+        "description": "A (WIP) JavaScript linter written in Rust designed to be as fast as possible, customizable, and easy to use.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Railroader": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://railroader.org",
+        "source": "https://github.com/david-a-wheeler/railroader",
+        "description": "An open source static analysis security vulnerability scanner for Ruby on Rails applications.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ReSharper": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "asp",
+            "csharp",
+            "javascript",
+            "typescript",
+            "vbnet"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.jetbrains.com/resharper",
+        "source": null,
+        "description": "Extends Visual Studio with on-the-fly code inspections for C#, VB.NET, ASP.NET, JavaScript, TypeScript and other technologies.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Refactoring Essentials": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp",
+            "vbnet"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://marketplace.visualstudio.com/items?itemName=SharpDevelopTeam.RefactoringEssentialsforVisualStudio",
+        "source": "https://github.com/icsharpcode/RefactoringEssentials",
+        "description": "The free Visual Studio 2015 extension for C# and VB.NET refactorings, including code best practice analyzers.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Reshift": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.reshiftsecurity.com",
+        "source": null,
+        "description": "A source code analysis tool for detecting and managing Java security vulnerabilities.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "3 Minute Reshift Demo 2020",
+                "url": "https://www.youtube.com/watch?v=GspuLMF3Vyo"
+            }
+        ],
+        "wrapper": null
+    },
+    "Reviewdog": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/haya14busa/reviewdog",
+        "source": "https://github.com/haya14busa/reviewdog",
+        "description": "A tool for posting review comments from any linter in any code hosting service.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Rome": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript",
+            "typescript"
+        ],
+        "other": [
+            "css",
+            "html",
+            "markdown"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://rome.tools/",
+        "source": "https://github.com/rome/tools",
+        "description": "Rome is a linter, compiler, bundler, and [more](https://rome.tools/#development-status) for JavaScript, TypeScript, JSON, HTML, Markdown, and CSS.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Roslyn Analyzers": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "dotnet",
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/dotnet/roslyn-analyzers",
+        "source": "https://github.com/dotnet/roslyn-analyzers",
+        "description": "Roslyn-based implementation of FxCop analyzers.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Roslyn Security Guard": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp",
+            "vbnet"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU Lesser General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://security-code-scan.github.io",
+        "source": "https://github.com/security-code-scan/security-code-scan",
+        "description": "Project that focuses on the identification of potential vulnerabilities such as SQL injection, cross-site scripting (XSS), CSRF, cryptography weaknesses, hardcoded passwords and many more.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Roslynator": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/JosefPihrt/Roslynator",
+        "source": "https://github.com/JosefPihrt/Roslynator",
+        "description": "A collection of 190+ analyzers and 190+ refactorings for C#, powered by Roslyn.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "RuboCop": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://docs.rubocop.org/rubocop",
+        "source": "https://github.com/rubocop-hq/rubocop",
+        "description": "A Ruby static code analyzer, based on the community Ruby style guide.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Rubrowser": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/blazeeboy/rubrowser",
+        "source": "https://github.com/blazeeboy/rubrowser",
+        "description": "Ruby classes interactive dependency graph generator.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Rudra": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/sslab-gatech/Rudra",
+        "source": "https://github.com/sslab-gatech/Rudra",
+        "description": "Rust Memory Safety & Undefined Behavior Detection. It is capable of analyzing single Rust packages as well as all the packages on crates.io.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Rust Language Server": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://github.com/rust-lang-nursery/rls",
+        "source": "https://github.com/rust-lang-nursery/rls",
+        "description": "Supports functionality such as 'goto definition', symbol search, reformatting, and code completion, and enables renaming and refactorings.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "RustViz": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/rustviz/rustviz",
+        "source": "https://github.com/rustviz/rustviz",
+        "description": "RustViz is a tool that generates visualizations  from simple Rust programs to assist users in better  understanding the Rust Lifetime and Borrowing mechanism. It generates SVG files with graphical indicators that integrate  with mdbook to render visualizations of data-flow in Rust programs.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "SPARK": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ada"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.adacore.com/about-spark",
+        "source": null,
+        "description": "Static analysis and formal verification toolset for Ada.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "SQLFluff": {
+        "categories": [
+            "linter",
+            "formatter"
+        ],
+        "languages": [
+            "sql"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.sqlfluff.com/",
+        "source": "https://github.com/sqlfluff/sqlfluff",
+        "description": "Multiple dialect SQL linter and formatter.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Official SQLFluff documentation",
+                "url": "https://docs.sqlfluff.com/en/stable/"
+            }
+        ],
+        "wrapper": null
+    },
+    "STOKE": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "asm"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/StanfordPL/stoke",
+        "source": "https://github.com/StanfordPL/stoke",
+        "description": "A programming-language agnostic stochastic optimizer for the x86_64 instruction set. It uses random search to explore the extremely high-dimensional space of all possible program transformations.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "SVF": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://svf-tools.github.io/SVF",
+        "source": "https://github.com/SVF-tools/SVF",
+        "description": "A static tool that enables scalable and precise interprocedural dependence analysis for C and C++ programs.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Saikuro": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://metricfu.github.io/Saikuro",
+        "source": "https://github.com/metricfu/Saikuro",
+        "description": "A Ruby cyclomatic complexity analyzer.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "SandiMeter": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://rubygems.org/gems/sandi_meter",
+        "source": "https://github.com/makaroni4/sandi_meter",
+        "description": "Static analysis tool for checking Ruby code for Sandi Metz' rules.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "Scalastyle": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "scala"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.scalastyle.org",
+        "source": "https://github.com/scalastyle/scalastyle",
+        "description": "Scalastyle examines your Scala code and indicates potential problems with it.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Scanmycode CE (Community Edition)": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go",
+            "java",
+            "javascript",
+            "php",
+            "python",
+            "ruby",
+            "scala"
+        ],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "BSD-3 Clause License with LGPL-2.1 with Commonsclause."
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "http://www.scanmycode.today",
+        "source": "https://github.com/marcinguy/scanmycode-ce",
+        "description": "Scanmycode - Code Scanning/SAST/Linting using many tools/Scanners with One Report",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Scrutinizer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go",
+            "java",
+            "javascript",
+            "php",
+            "python",
+            "ruby",
+            "typescript"
+        ],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://scrutinizer-ci.com",
+        "source": null,
+        "description": "A proprietary code quality checker that can be integrated with GitHub.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "SearchDiggity": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://resources.bishopfox.com/resources/tools/google-hacking-diggity/attack-tools/",
+        "source": null,
+        "description": "Identifies vulnerabilities in open source code projects  hosted on Github, Google Code, MS CodePlex, SourceForge, and more.  The tool comes with over 130 default searches that identify SQL injection,  cross-site scripting (XSS), insecure remote and local file includes, hard-coded passwords, etc. ",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Security Code Scan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "java",
+            "php",
+            "vbnet"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU Lesser General Public License v3.0"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://security-code-scan.github.io",
+        "source": "https://github.com/security-code-scan/security-code-scan",
+        "description": "Security code analyzer for C# and VB.NET. Detects various security vulnerability patterns: SQLi, XSS, CSRF, XXE, Open Redirect, etc. Integrates into Visual Studio 2015 and newer. Detects various security vulnerability patterns: SQLi, XSS, CSRF, XXE, Open Redirect, etc.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Semgrep": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "go",
+            "java",
+            "javascript",
+            "jsx",
+            "ocaml",
+            "php",
+            "python",
+            "ruby",
+            "typescript"
+        ],
+        "other": [
+            "configmanagement",
+            "ci",
+            "dockerfile",
+            "ide",
+            "json",
+            "kubernetes",
+            "nodejs",
+            "rails",
+            "security",
+            "terraform",
+            "yaml"
+        ],
+        "licenses": [
+            "GNU Lesser General Public License v2.1"
+        ],
+        "types": [
+            "cli",
+            "service"
+        ],
+        "homepage": "https://semgrep.dev",
+        "source": "https://github.com/returntocorp/semgrep",
+        "description": "A fast, open-source, static analysis tool for finding bugs and enforcing code standards at editor, commit, and CI time. Its rules look like the code you already write;  no abstract syntax trees or regex wrestling. Supports 17+ languages.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ShiftLeft": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp",
+            "go",
+            "java",
+            "javascript",
+            "jsp",
+            "python",
+            "scala"
+        ],
+        "other": [
+            "configmanagement",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.shiftleft.io",
+        "source": null,
+        "description": "Identify vulnerabilities that are unique to your code base before they reach production. Leverages the Code Property Graph (CPG) to run its analyses concurrently in a single graph of graphs. Automatically finds business logic flaws in dev like hardcoded secrets and logic bombs",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Securing Every Pull Request with ShiftLeft",
+                "url": "https://vimeo.com/383381584"
+            },
+            {
+                "title": "ShiftLeft Intro",
+                "url": "https://vimeo.com/233423863"
+            }
+        ],
+        "wrapper": null
+    },
+    "ShiftLeft Scan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "apex",
+            "go",
+            "groovy",
+            "java",
+            "jsp",
+            "kotlin",
+            "php",
+            "plsql",
+            "python",
+            "ruby",
+            "rust",
+            "scala",
+            "shell",
+            "vbasic"
+        ],
+        "other": [
+            "configmanagement",
+            "container",
+            "json",
+            "nodejs",
+            "yaml"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "service",
+            "cli"
+        ],
+        "homepage": "https://slscan.io",
+        "source": "https://github.com/ShiftLeftSecurity/sast-scan",
+        "description": "Scan is a free open-source DevSecOps platform for detecting security issues in source code and dependencies. It supports a broad range of languages and CI/CD pipelines.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Sider": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go",
+            "python",
+            "ruby",
+            "swift"
+        ],
+        "other": [
+            "ci",
+            "css"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://sider.review",
+        "source": null,
+        "description": "An automated code reviewing tool. Improving developers' productivity.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Similarity Tester": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "asm",
+            "c",
+            "cpp",
+            "java",
+            "lisp",
+            "miranda",
+            "modula-2",
+            "pascal"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause Revised License"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://dickgrune.com/Programs/similarity_tester/",
+        "source": null,
+        "description": "A tool that finds similarities between or within files to support you encountering DRY principle violations.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Snyk": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go",
+            "java",
+            "javascript",
+            "php",
+            "python",
+            "ruby"
+        ],
+        "other": [
+            "container",
+            "ci",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://snyk.io",
+        "source": null,
+        "description": "Vulnerability scanner for dependencies of node.js apps (free for Open Source Projects).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "SonarCloud": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "abap",
+            "apex",
+            "csharp",
+            "cpp",
+            "go",
+            "java",
+            "javascript",
+            "kotlin",
+            "python",
+            "ruby",
+            "swift",
+            "typescript"
+        ],
+        "other": [
+            "ci",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://sonarcloud.io",
+        "source": null,
+        "description": "Multi-language cloud-based static code analysis. History, trends, security hot-spots, pull request analysis and more. Free for open source.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "SonarLint for Visual Studio": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "javascript",
+            "vbnet"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU Lesser General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://vs.sonarlint.org",
+        "source": "https://github.com/SonarSource/sonarlint-visualstudio",
+        "description": "SonarLint is an extension for Visual Studio 2015 and 2017 that provides on-the-fly feedback to developers on new bugs and quality issues injected into .NET code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "SonarQube": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp",
+            "go",
+            "java",
+            "javascript",
+            "kotlin",
+            "php",
+            "python",
+            "ruby",
+            "scala",
+            "typescript"
+        ],
+        "other": [
+            "ci",
+            "css",
+            "html",
+            "xml"
+        ],
+        "licenses": [
+            "GNU Lesser General Public License v3.0"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "http://www.sonarqube.org",
+        "source": "https://github.com/SonarSource/sonarqube",
+        "description": "SonarQube is an open platform to manage code quality.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Write Cleaner, Safer, Modern C++ Code with SonarQube",
+                "url": "https://www.youtube.com/watch?v=WPHVPbxCAwE"
+            },
+            {
+                "title": "Write cleaner, safer Python code with SonarQube",
+                "url": "https://www.youtube.com/watch?v=ow-yuIlCuHk"
+            }
+        ],
+        "wrapper": null
+    },
+    "Sonatype": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "clojure",
+            "coffeescript",
+            "fsharp",
+            "go",
+            "groovy",
+            "java",
+            "javascript",
+            "kotlin",
+            "objectivec",
+            "php",
+            "python",
+            "r",
+            "ruby",
+            "rust",
+            "scala",
+            "swift",
+            "vbasic"
+        ],
+        "other": [
+            "ci",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.sonatype.com",
+        "source": "https://www.sonatype.com",
+        "description": "Reports known vulnerabilities in common dependencies and recommends updated packages to minimize breaking changes",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Soot": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU Lesser General Public License v2.1"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://soot-oss.github.io/soot",
+        "source": "https://github.com/soot-oss/soot",
+        "description": "A framework for analyzing and transforming Java and Android applications.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Sorbet": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://sorbet.org",
+        "source": "https://github.com/sorbet/sorbet",
+        "description": "A fast, powerful type checker designed for Ruby.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Soto Platform": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "abap",
+            "c",
+            "csharp",
+            "cpp",
+            "java",
+            "php",
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.hello2morrow.com/products/sotograph",
+        "source": null,
+        "description": "Suite of static analysis tools consisting of the three components Sotoarc (Architecture Analysis), Sotograph (Quality Analysis), and Sotoreport (Quality report). Helps find differences between architecture and implementation, interface violations (e.g. external access of private parts of subsystems, detection of all classes, files, packages and subsystems which are strongly coupled by cyclical relationships and more. The Sotograph product family runs on Windows and Linux. ",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "SourceMeter": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "java",
+            "python",
+            "rpg"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.sourcemeter.com/",
+        "source": null,
+        "description": "Static Code Analysis for C/C++, Java, C#, Python, and RPG III and RPG IV versions (including free-form).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Specificity Graph": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "css"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://jonassebastianohlsson.com/specificity-graph",
+        "source": "https://github.com/pocketjoso/specificity-graph",
+        "description": "CSS Specificity Graph Generator.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Spectral": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "json",
+            "yaml"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://stoplight.io/open-source/spectral",
+        "source": "https://github.com/stoplightio/spectral",
+        "description": "A flexible JSON/YAML linter, without of the box support for OpenAPI v2/v3 and AsyncAPI v2.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Spoon": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://spoon.gforge.inria.fr",
+        "source": "https://github.com/INRIA/spoon",
+        "description": "Spoon is a metaprogramming library to analyze and transform Java source code (incl Java 9, 10, 11, 12, 13, 14). It parses source files to build a well-designed AST with powerful analysis and transformation API. Can be integrated in Maven and Gradle.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "SpotBugs": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU Lesser General Public License v2.1"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://spotbugs.github.io",
+        "source": "https://github.com/spotbugs/spotbugs",
+        "description": "SpotBugs is FindBugs' successor. A tool for static analysis to look for bugs in Java code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Stan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "haskell"
+        ],
+        "other": [],
+        "licenses": [
+            "Mozilla Public License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://kowainik.github.io/projects/stan",
+        "source": "https://github.com/kowainik/stan",
+        "description": "Stan is a command-line tool for analysing Haskell projects and outputting discovered vulnerabilities in a helpful way with possible solutions for detected problems.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Standard Ruby": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/testdouble/standard",
+        "source": "https://github.com/testdouble/standard",
+        "description": "Ruby Style Guide, with linter & automatic code fixer",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "StaticLint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "julia"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/julia-vscode/StaticLint.jl",
+        "source": "https://github.com/julia-vscode/StaticLint.jl",
+        "description": "Static Code Analysis for Julia",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Steep": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/soutaro/steep",
+        "source": "https://github.com/soutaro/steep",
+        "description": "Gradual Typing for Ruby.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Stylelint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "css"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://stylelint.io",
+        "source": "https://github.com/stylelint/stylelint",
+        "description": "Linter for SCSS/CSS files.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Super-Linter": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "coffeescript",
+            "go",
+            "javascript",
+            "perl",
+            "python",
+            "ruby",
+            "shell",
+            "typescript"
+        ],
+        "other": [
+            "configmanagement",
+            "container",
+            "json",
+            "markdown",
+            "xml",
+            "yaml"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/github/super-linter",
+        "source": "https://github.com/github/super-linter",
+        "description": "Combination of multiple linters to install as a GitHub Action.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "SwiftFormat": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "swift"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/nicklockwood/SwiftFormat",
+        "source": "https://github.com/nicklockwood/SwiftFormat",
+        "description": "A library and command-line formatting tool for reformatting Swift code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "SwiftLint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "swift"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://realm.github.io/SwiftLint",
+        "source": "https://github.com/realm/SwiftLint",
+        "description": "A tool to enforce Swift style and conventions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Symfony Insight": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [
+            "ci",
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://insight.symfony.com/",
+        "source": null,
+        "description": "Detect security risks, find bugs and provide actionable metrics for PHP projects.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Synopsys": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "fortran",
+            "java",
+            "javascript",
+            "php",
+            "python",
+            "ruby",
+            "swift"
+        ],
+        "other": [
+            "ci",
+            "mobile",
+            "nodejs"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.synopsys.com/software-integrity/security-testing/static-analysis-sast.html",
+        "source": null,
+        "description": "A commercial static analysis platform that allows for scanning of multiple languages (C/C++, Android, C#, Java, JS, PHP, Python, Node.JS, Ruby, Fortran, and Swift).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Sys": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ocaml"
+        ],
+        "other": [],
+        "licenses": [
+            "GPL-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/PLSysSec/sys",
+        "source": "https://github.com/PLSysSec/sys",
+        "description": "A static/symbolic Tool for finding bugs in (browser) code. It uses the LLVM AST to find bugs like uninitialized memory access.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "TSqlRules": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "sql"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/ashleyglee/TSqlRules",
+        "source": "https://github.com/ashleyglee/TSqlRules",
+        "description": "TSQL Static Code Analysis Rules for SQL Server.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Tailor": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "swift"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://sleekbyte.github.io/tailor",
+        "source": "https://github.com/sleekbyte/tailor",
+        "description": "A static analysis and lint tool for source code written in Apple's Swift programming language.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "TeXLab": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "latex"
+        ],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://texlab.netlify.app",
+        "source": "https://github.com/latex-lsp/texlab",
+        "description": "A Language Server Protocol implementation for TeX/LaTeX, including lint capabilities.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Teamscale": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "abap",
+            "c",
+            "csharp",
+            "cpp",
+            "java"
+        ],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "ide-plugin",
+            "service"
+        ],
+        "homepage": "https://www.cqse.eu/en/teamscale/overview/",
+        "source": null,
+        "description": "Static and dynamic analysis tool supporting more than 25 languages and direct IDE integration. Free hosting for Open Source projects available on request. Free academic licenses available.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "CQSE Webinar: Architekturanalyse mit Teamscale (German)",
+                "url": "https://www.youtube.com/watch?v=fJVjv0153-U"
+            },
+            {
+                "title": "Teamscale Integration for Visual Studio",
+                "url": "https://marketplace.visualstudio.com/items?itemName=CQSEGmbH.Teamscale"
+            }
+        ],
+        "wrapper": null
+    },
+    "Test Design Studio": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "vbscript"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://patterson-consulting.net/tds",
+        "source": null,
+        "description": "A full IDE with static code analysis for Micro Focus Unified Functional Testing VBScript-based automated tests.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "TscanCode": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "lua"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Tencent/TscanCode",
+        "source": "https://github.com/Tencent/TscanCode",
+        "description": "A fast and accurate static analysis solution for C/C++, C#, Lua codes provided by Tencent. Using GPLv3 license.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Tsunami Security Scanner": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "security"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/google/tsunami-security-scanner",
+        "source": "https://github.com/google/tsunami-security-scanner",
+        "description": "A general purpose network security scanner with an extensible plugin system for  detecting high severity RCE-like vulnerabilities with high confidence. Custom detectors for finding vulnerabilities (e.g. open APIs) can be added.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Tsunami Security Scanner from Google: Identify Critical vulnerabilities with high confidence - LAB",
+                "url": "https://www.youtube.com/watch?v=SMlWes1XnWw"
+            }
+        ],
+        "wrapper": null
+    },
+    "Tuli": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/ircmaxell/Tuli",
+        "source": "https://github.com/ircmaxell/Tuli",
+        "description": "A static analysis engine.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Twiggy": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary",
+            "wasm"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://rustwasm.github.io/twiggy",
+        "source": "https://github.com/rustwasm/twiggy",
+        "description": "Analyzes a binary's call graph to profile code size. The goal is to slim down wasm binary size.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "TypL": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://typl.dev",
+        "source": "https://github.com/getify/TypL",
+        "description": "With TypL, you just write completely standard JS, and the tool figures out your types via powerful inferencing.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "TypeScript Call Graph": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/whyboris/TypeScript-Call-Graph",
+        "source": "https://github.com/whyboris/TypeScript-Call-Graph",
+        "description": "CLI to generate an interactive graph of functions and calls from your TypeScript files",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "TypeScript ESLint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/typescript-eslint/typescript-eslint",
+        "source": "https://github.com/typescript-eslint/typescript-eslint",
+        "description": "TypeScript language extension for eslint.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "VSCode ESLint, Prettier & Airbnb Style Guide Setup",
+                "url": "https://www.youtube.com/watch?v=SydnKbGc7W8"
+            }
+        ],
+        "wrapper": null
+    },
+    "Undebt": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "java",
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Yelp/undebt",
+        "source": "https://github.com/Yelp/undebt",
+        "description": "Language-independent tool for massive, automatic, programmable refactoring based on simple pattern definitions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Understand": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ada",
+            "asm",
+            "c",
+            "csharp",
+            "cpp",
+            "cobol",
+            "delphi",
+            "fortran",
+            "java",
+            "javascript",
+            "php",
+            "python",
+            "typescript",
+            "vhdl",
+            "vbnet"
+        ],
+        "other": [
+            "css",
+            "html",
+            "xml"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.scitools.com",
+        "source": null,
+        "description": "Code visualization tool that provides code analysis, standards testing, metrics, graphing, dependency analysis and more for Ada, VHDL, and others.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Unibeautify": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "go",
+            "java",
+            "javascript",
+            "jsx",
+            "objectivec",
+            "php",
+            "python",
+            "typescript"
+        ],
+        "other": [
+            "css",
+            "html",
+            "markdown",
+            "vue"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli",
+            "service"
+        ],
+        "homepage": "https://unibeautify.com",
+        "source": "https://github.com/unibeautify/unibeautify",
+        "description": "Universal code beautifier with a GitHub app. Supports HTML, CSS, JavaScript, TypeScript, JSX, Vue, C++, Go, Objective-C, Java, Python, PHP, GraphQL, Markdown, and more.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Upsource": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java",
+            "javascript",
+            "kotlin",
+            "php"
+        ],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.jetbrains.com/upsource",
+        "source": null,
+        "description": "Code review tool with static code analysis and code-aware navigation for Java, PHP, JavaScript and Kotlin.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Upsource - Code Review Best Practices",
+                "url": "https://www.youtube.com/watch?v=EjwD7Pi7J_0"
+            }
+        ],
+        "wrapper": null
+    },
+    "VMware chap": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "GPL v2"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/vmware/chap",
+        "source": "https://github.com/vmware/chap",
+        "description": "chap analyzes un-instrumented ELF core files for leaks, memory growth, and corruption.  It is sufficiently reliable that it can be used in automation to catch leaks before  they are committed. As an interactive tool, it helps explain memory growth,  can identify some forms of corruption, and supplements a debugger  by giving the status of various memory locations. ",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "VSDiagnostics": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Vannevelj/VSDiagnostics",
+        "source": "https://github.com/Vannevelj/VSDiagnostics",
+        "description": "A collection of static analyzers based on Roslyn that integrates with VS.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Veracode": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "dotnet",
+            "c",
+            "cpp",
+            "java",
+            "javascript",
+            "objectivec",
+            "php",
+            "swift"
+        ],
+        "other": [
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.veracode.com/products/static-analysis-sast/static-code-analysis",
+        "source": null,
+        "description": "Find flaws in binaries and bytecode without requiring source. Support all major programming languages: Java, .NET, JavaScript, Swift, Objective-C, C, C++ and more.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Veracode Overview",
+                "url": "https://www.youtube.com/watch?v=6Fq_UMgwX4I"
+            },
+            {
+                "title": "Ten Years in the Making - Veracode (behind the scenes)",
+                "url": "https://www.youtube.com/watch?v=CacOX9ytugc"
+            }
+        ],
+        "wrapper": null
+    },
+    "VeriFast": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ocaml"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/verifast/verifast",
+        "source": "https://github.com/verifast/verifast",
+        "description": "A tool for modular formal verification of correctness properties of single-threaded and multithreaded  C and Java programs annotated with preconditions and postconditions written in separation logic.  To express rich specifications, the programmer can define inductive datatypes,  primitive recursive pure functions over these datatypes, and abstract separation logic predicates.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Verilator": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "verilog"
+        ],
+        "other": [],
+        "licenses": [
+            "GPL v3 or Perl Artistic License Version 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.veripool.org/verilator",
+        "source": "https://github.com/verilator/verilator",
+        "description": "A tool which converts Verilog to a cycle-accurate behavioral model in C++ or SystemC. Performs lint code-quality checks.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Vetur": {
+        "categories": [
+            "formatter",
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "vue"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "ide-plugin",
+            "cli"
+        ],
+        "homepage": "https://marketplace.visualstudio.com/items?itemName=octref.vetur",
+        "source": "https://github.com/vuejs/vetur",
+        "description": "Vue tooling for VS Code, powered by vls (vue language server). Vetur has support for formatting embedded HTML, CSS, SCSS, JS, TypeScript, and more. Vetur only has a \"whole document formatter\" and cannot format arbitrary ranges.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Pine Wu - var vetur = vscode + vue; | VueConf 2017",
+                "url": "https://www.youtube.com/watch?v=05tNXJ-Kric"
+            }
+        ],
+        "wrapper": null
+    },
+    "Viezly": {
+        "categories": [
+            "tool"
+        ],
+        "languages": [
+            "csharp",
+            "go",
+            "javascript",
+            "kotlin",
+            "python",
+            "ruby",
+            "typescript"
+        ],
+        "other": [
+            "ci",
+            "rails"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://viezly.com",
+        "source": null,
+        "description": "Code review tool with dependency diagrams. Improve your team's code reviews with better navigation and code analysis",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Violations Lib": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [
+            "ci",
+            "support"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/tomasbjerre/violations-lib",
+        "source": "https://github.com/tomasbjerre/violations-lib",
+        "description": "Java library for parsing report files from static code analysis. Used by a bunch of Jenkins, Maven and Gradle plugins.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Visual Expert": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "sql"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.visual-expert.com",
+        "source": null,
+        "description": "Code analysis for PowerBuilder, Oracle, and SQL Server Explores, analyzes, and documents Code ",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Vuls": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "container"
+        ],
+        "licenses": [
+            "AGPL-3.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://vuls.io/",
+        "source": "https://github.com/future-architect/vuls",
+        "description": "Agent-less Linux vulnerability scanner based on information from NVD, OVAL, etc.  It has some container image support, although is not a container specific tool.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "WALA": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java",
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "Eclipse Public License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/wala/WALA",
+        "source": "https://github.com/wala/WALA",
+        "description": "Static analysis capabilities for Java bytecode and related languages and for JavaScript.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "WALA Everywhere",
+                "url": "https://www.youtube.com/watch?v=QtrJEopSSuw"
+            }
+        ],
+        "wrapper": null
+    },
+    "WAP": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU GPL"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://securityonline.info/owasp-wap-web-application-protection-project",
+        "source": "http://awap.sourceforge.net/index.html",
+        "description": "Tool to detect and correct input validation vulnerabilities in PHP (4.0 or higher) web applications and predicts false positives by combining static analysis and data mining.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "WartRemover": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "scala"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.wartremover.org",
+        "source": "https://github.com/puffnfresh/wartremover",
+        "description": "A flexible Scala code linting tool.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Weeder": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "haskell"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/ocharles/weeder",
+        "source": "https://github.com/ocharles/weeder",
+        "description": "A tool for detecting dead exports or package imports in Haskell code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "WhiteHat Application Security Platform": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "aspnet",
+            "csharp",
+            "java",
+            "javascript",
+            "objectivec",
+            "php",
+            "typescript"
+        ],
+        "other": [
+            "html",
+            "mobile",
+            "nodejs"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.whitehatsec.com/platform/static-application-security-testing",
+        "source": null,
+        "description": "WhiteHat Scout (for Developers) combined with WhiteHat Sentinel Source (for Operations) supporting WhiteHat Top 40 and OWASP Top 10.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Wintellect.Analyzers": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Wintellect/Wintellect.Analyzers",
+        "source": "https://github.com/Wintellect/Wintellect.Analyzers",
+        "description": ".NET Compiler Platform (\"Roslyn\") diagnostic analyzers and code fixes.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "Wotan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript",
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/fimbullinter/wotan",
+        "source": "https://github.com/fimbullinter/wotan",
+        "description": "Pluggable TypeScript and JavaScript linter.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "XCode": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "objectivec"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://developer.apple.com/xcode",
+        "source": null,
+        "description": "XCode provides a pretty decent UI for [Clang's](http://clang-analyzer.llvm.org/xcode.html) static code analyzer (C/C++, Obj-C).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ZPA": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "plsql"
+        ],
+        "other": [],
+        "licenses": [
+            "LGPL-3.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://felipezorzo.com.br/zpa/",
+        "source": "https://github.com/felipebz/zpa",
+        "description": "Z PL/SQL Analyzer (ZPA) is an extensible code analyzer for PL/SQL and Oracle SQL. It can be integrated with SonarQube.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "abapOpenChecks": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "abap"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://docs.abapopenchecks.org",
+        "source": "https://github.com/larshp/abapOpenChecks",
+        "description": "Enhances the SAP Code Inspector with new and customizable checks.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "abaplint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "abap"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "service",
+            "ide-plugin",
+            "cli"
+        ],
+        "homepage": "https://abaplint.org",
+        "source": "https://github.com/abaplint/abaplint",
+        "description": "Linter for ABAP, written in TypeScript.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "actionlint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://rhysd.github.io/actionlint",
+        "source": "https://github.com/rhysd/actionlint",
+        "description": "Static checker for GitHub Actions workflow files. Provides an online version.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "aether": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://aetherjs.com",
+        "source": "https://github.com/codecombat/aether",
+        "description": "Lint, analyze, normalize, transform, sandbox, run, step through, and visualize user JavaScript, in node or the browser.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ale": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript",
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 2-Clause \"Simplified\" License"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://github.com/w0rp/ale",
+        "source": "https://github.com/w0rp/ale",
+        "description": "Asynchronous Lint Engine for Vim and NeoVim with support for many languages.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "alex": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "writing"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://alexjs.com",
+        "source": "https://github.com/get-alex/alex",
+        "description": "Catch insensitive, inconsiderate writing",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "aligncheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "GPL v2"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://gitlab.com/opennota/check",
+        "source": "https://gitlab.com/opennota/check",
+        "description": "Find inefficiently packed structs.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ameba": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "crystal"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://crystal-ameba.github.io",
+        "source": "https://github.com/crystal-ameba/ameba",
+        "description": "A static code analysis tool for Crystal.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "anchore": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "container"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://anchore.io",
+        "source": "https://github.com/anchore/anchore-engine",
+        "description": "Discover, analyze, and certify container images. A service that analyzes Docker images and applies user-defined acceptance policies  to allow automated container image validation and certification ",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "android-lint-summary": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "mobile"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://passy.github.io/android-lint-summary",
+        "source": "https://github.com/passy/android-lint-summary",
+        "description": "Combines lint errors of multiple projects into one output, check lint results of multiple sub-projects at once.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "angr": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "BSD 2-Clause \"Simplified\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/angr/angr",
+        "source": null,
+        "description": "Binary code analysis tool that also supports symbolic execution.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ansible-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://docs.ansible.com/ansible-lint",
+        "source": "https://github.com/willthames/ansible-lint",
+        "description": "Checks playbooks for practices and behaviour that could potentially be improved.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "bandit": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://bandit.readthedocs.io/en/latest",
+        "source": "https://github.com/PyCQA/bandit",
+        "description": "A tool to find common security issues in Python code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "bashate": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "shell"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/openstack/bashate",
+        "source": "https://github.com/openstack/bashate",
+        "description": "Code style enforcement for bash programs. The output format aims to follow pycodestyle (pep8) default output format.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Official bashate documentation",
+                "url": "https://docs.openstack.org/bashate"
+            }
+        ],
+        "wrapper": null
+    },
+    "bellybutton": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/hchasestevens/bellybutton",
+        "source": "https://github.com/hchasestevens/bellybutton",
+        "description": "A linting engine supporting custom project-specific rules.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "binbloom": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/quarkslab/binbloom",
+        "source": "https://github.com/quarkslab/binbloom",
+        "description": "Analyzes a raw binary firmware and determines features like endianness or the loading address.  The tool is compatible with all architectures.\nLoading address: binbloom can parse a raw binary firmware and determine its loading address. Endianness: binbloom can use heuristics to determine the endianness of a firmware. UDS Database: binbloom can parse a raw binary firmware and check if it contains an array containing UDS command IDs.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Tutorial: Binbloom - Raw Binary Firmware Analysis Software",
+                "url": "https://www.kitploit.com/2020/10/binbloom-raw-binary-firmware-analysis.html?m=1"
+            }
+        ],
+        "wrapper": null
+    },
+    "bloaty": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/google/bloaty",
+        "source": "https://github.com/google/bloaty",
+        "description": "Ever wondered what's making your binary big? Bloaty McBloatface will show you a size profile of the binary so you can understand what's taking up space inside. Bloaty performs a deep analysis of the binary. Using custom ELF, DWARF, and Mach-O parsers,  Bloaty aims to accurately attribute every byte of the binary to the symbol or compileunit that produced it.  It will even disassemble the binary looking for references to anonymous data. F",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "bodyclose": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/timakin/bodyclose",
+        "source": "https://github.com/timakin/bodyclose",
+        "description": "Checks whether HTTP response body is closed.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "brakeman": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [
+            "security"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://brakemanscanner.org",
+        "source": "https://github.com/presidentbeef/brakeman",
+        "description": "A static analysis security vulnerability scanner for Ruby on Rails applications.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "brittany": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "haskell"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU Affero General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/lspitzner/brittany",
+        "source": "https://github.com/lspitzner/brittany",
+        "description": "Haskell source code formatter",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "buf": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "protobuf"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://buf.build",
+        "source": "https://github.com/bufbuild/buf",
+        "description": "Provides a CLI linter that enforces good API design choices and structure",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "bundler-audit": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/rubysec/bundler-audit",
+        "source": "https://github.com/rubysec/bundler-audit",
+        "description": "Audit Gemfile.lock for gems with security vulnerabilities reported in [Ruby Advisory Database](https://github.com/rubysec/ruby-advisory-db).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cane": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/square/cane",
+        "source": "https://github.com/square/cane",
+        "description": "Code quality threshold checking as part of your build.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cargo udeps": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License / Apache 2.0 license"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/est31/cargo-udeps",
+        "source": "https://github.com/est31/cargo-udeps",
+        "description": "Find unused dependencies in Cargo.toml. It either prints out a \"unused crates\" line listing the crates,  or it prints out a line saying that no crates were unused.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cargo-audit": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://rustsec.org",
+        "source": "https://github.com/RustSec/cargo-audit",
+        "description": "Audit Cargo.lock for crates with security vulnerabilities reported to the [RustSec Advisory Database](https://github.com/RustSec/advisory-db/).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cargo-bloat": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/RazrFalcon/cargo-bloat",
+        "source": "https://github.com/RazrFalcon/cargo-bloat",
+        "description": "Find out what takes most of the space in your executable. supports ELF (Linux, BSD), Mach-O (macOS) and PE (Windows) binaries.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cargo-deny": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://embarkstudios.github.io/cargo-deny",
+        "source": "https://github.com/EmbarkStudios/cargo-deny",
+        "description": "A cargo plugin for linting your dependencies. It can be used either as a command line too, a Rust crate, or a Github action for CI. It checks for valid license information, duplicate crates, security vulnerabilities, and more.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cargo-expand": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/dtolnay/cargo-expand",
+        "source": "https://github.com/dtolnay/cargo-expand",
+        "description": "Cargo subcommand to show result of macro expansion  and #[derive] expansion applied to the current crate.  This is a wrapper around a more verbose compiler command.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cargo-inspect": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mre/cargo-inspect",
+        "source": "https://github.com/mre/cargo-inspect",
+        "description": "Inspect Rust code without syntactic sugar to see what the compiler does behind the curtains.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cargo-spellcheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache 2.0 / MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/drahnr/cargo-spellcheck",
+        "source": "https://github.com/drahnr/cargo-spellcheck",
+        "description": "Checks all your documentation for spelling and grammar mistakes  with hunspell (ready) and languagetool (preview)",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cfn-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/awslabs/cfn-python-lint",
+        "source": "https://github.com/awslabs/cfn-python-lint",
+        "description": "AWS Labs CloudFormation linter.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cfn_nag": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/stelligent/cfn_nag",
+        "source": "https://github.com/stelligent/cfn_nag",
+        "description": "A linter for AWS CloudFormation templates.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "chart-testing": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement",
+            "container",
+            "kubernetes"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/helm/chart-testing",
+        "source": "https://github.com/helm/chart-testing",
+        "description": "ct is the the tool for testing Helm charts.  It is meant to be used for linting and testing pull requests.  It automatically detects charts changed against the target branch.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "checkmake": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "buildtool",
+            "make"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mrtazz/checkmake",
+        "source": "https://github.com/mrtazz/checkmake",
+        "description": "Linter / Analyzer for Makefiles.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "checkov": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement"
+        ],
+        "licenses": [
+            "Apache-2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.checkov.io",
+        "source": "https://github.com/bridgecrewio/checkov",
+        "description": "Static analysis tool for Terraform files (tf>=v0.12), preventing cloud misconfigs at build time.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "checkstyle": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://checkstyle.org",
+        "source": "https://github.com/checkstyle/checkstyle",
+        "description": "Checking Java source code for adherence to a Code Standard or set of validation rules (best practices).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "churn-php": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/bmitch/churn-php",
+        "source": "https://github.com/bmitch/churn-php",
+        "description": "Helps discover good candidates for refactoring.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ciocheck": {
+        "categories": [
+            "formatter",
+            "meta"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [
+            "meta"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/ContinuumIO/ciocheck",
+        "source": "https://github.com/ContinuumIO/ciocheck",
+        "description": "Linter, formatter and test suite helper. As a linter, it is a wrapper around `pep8`, `pydocstyle`, `flake8`, and `pylint`.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mauricioaniche/ck",
+        "source": "https://github.com/mauricioaniche/ck",
+        "description": "Calculates Chidamber and Kemerer object-oriented metrics by processing the source Java files.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ckjm": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.spinellis.gr/sw/ckjm",
+        "source": "https://github.com/dspinellis/ckjm",
+        "description": "Calculates Chidamber and Kemerer object-oriented metrics by processing the bytecode of compiled Java files.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "clair": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "container"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/coreos/clair",
+        "source": "https://github.com/coreos/clair",
+        "description": "Vulnerability Static Analysis for Containers.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "clang-tidy": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License v2.0 with LLVM Exceptions"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://clang.llvm.org/extra/clang-tidy",
+        "source": "http://clang.llvm.org/extra/clang-tidy",
+        "description": "clang static analyser.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "clazy": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "LGPL"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/KDE/clazy",
+        "source": "https://github.com/KDE/clazy",
+        "description": "Qt-oriented static code analyzer based on the Clang framework. clazy is a compiler plugin which allows clang to understand Qt semantics. You get more than 50 Qt related compiler warnings, ranging from unneeded memory allocations to misusage of API, including fix-its for automatic refactoring.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "clippy": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://rust-lang.github.io/rust-clippy",
+        "source": "https://github.com/rust-lang/rust-clippy",
+        "description": "A code linter to catch common mistakes and improve your Rust code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "clj-kondo": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "clojure"
+        ],
+        "other": [],
+        "licenses": [
+            "Eclipse Public License 1.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/borkdude/clj-kondo",
+        "source": "https://github.com/borkdude/clj-kondo",
+        "description": "A linter for Clojure code that sparks joy. It informs you about potential errors while you are typing.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "clusterlint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement",
+            "container",
+            "kubernetes"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/digitalocean/clusterlint",
+        "source": "https://github.com/digitalocean/clusterlint",
+        "description": "Clusterlint queries live Kubernetes clusters for resources, executes common and  platform specific checks against these resources and provides actionable feedback to cluster operators.  It is a non invasive tool that is run externally. Clusterlint does not alter the resource configurations.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "coala": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "java",
+            "javascript"
+        ],
+        "other": [
+            "css"
+        ],
+        "licenses": [
+            "AGPL-3.0-only"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://coala.io",
+        "source": "https://github.com/coala/coala",
+        "description": "Language independent framework for creating code analysis - supports [over 60 languages](https://coala.io/languages) by default.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "code-cracker": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "csharp"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://code-cracker.github.io",
+        "source": "https://github.com/code-cracker/code-cracker",
+        "description": "An analyzer library for C# and VB that uses Roslyn to produce refactorings, code analysis, and other niceties.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "codeburner": {
+        "categories": [
+            "meta"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "java",
+            "javascript",
+            "php"
+        ],
+        "other": [
+            "meta"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://groupon.github.io/codeburner",
+        "source": "https://github.com/groupon/codeburner",
+        "description": "Provides a unified interface to sort and act on the issues it finds.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "codechecker": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [
+            "buildtool"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://codechecker.readthedocs.io/en/latest",
+        "source": "https://github.com/Ericsson/codechecker",
+        "description": "A defect database and viewer extension for the Clang Static Analyzer with web GUI.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "codeql": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "java",
+            "javascript",
+            "python",
+            "typescript"
+        ],
+        "other": [
+            "ci",
+            "security"
+        ],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "ide-plugin",
+            "service"
+        ],
+        "homepage": "https://github.com/github/codeql",
+        "source": null,
+        "description": "Deep code analysis - semantic queries and dataflow for several languages with VSCode plugin support.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "codespell": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "writing"
+        ],
+        "licenses": [
+            "GNU General Public License v2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/codespell-project/codespell",
+        "source": "https://github.com/codespell-project/codespell",
+        "description": "Check code for common misspellings.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "coffeelint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "coffeescript"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.coffeelint.org",
+        "source": "https://github.com/clutchski/coffeelint",
+        "description": "A style checker that helps keep CoffeeScript code clean and consistent.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cohesion": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mschwager/cohesion",
+        "source": "https://github.com/mschwager/cohesion",
+        "description": "A tool for measuring Python class cohesion.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "collector": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [],
+        "other": [
+            "container"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/banyanops/collector",
+        "source": "https://github.com/banyanops/collector",
+        "description": "Run arbitrary scripts inside containers, and gather useful information.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "commitlint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "git"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://commitlint.js.org",
+        "source": "https://github.com/conventional-changelog/commitlint",
+        "description": "checks if your commit messages meet the conventional commit format",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "complexity-report": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/escomplex/complexity-report",
+        "source": "https://github.com/escomplex/complexity-report",
+        "description": "Software complexity analysis for JavaScript projects.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "cookstyle": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://docs.chef.io/cookstyle.html",
+        "source": "https://github.com/chef/cookstyle",
+        "description": "Cookstyle is a linting tool based on the RuboCop Ruby linting tool for Chef cookbooks.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cppcheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://cppcheck.sourceforge.net",
+        "source": "https://github.com/danmar/cppcheck",
+        "description": "Static analysis of C/C++ code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Cppcheck introduction",
+                "url": "https://www.viva64.com/en/t/0083/"
+            }
+        ],
+        "wrapper": null
+    },
+    "cpplint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache-2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/google/styleguide/tree/gh-pages/cpplint",
+        "source": "https://github.com/google/styleguide/tree/gh-pages/cpplint",
+        "description": "Automated C++ checker that follows Google's style guide.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cqc": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript",
+            "jsx"
+        ],
+        "other": [
+            "css",
+            "less",
+            "vue"
+        ],
+        "licenses": [
+            "BSD-3-Clause (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/xcatliu/cqc",
+        "source": "https://github.com/xcatliu/cqc",
+        "description": "Check your code quality for js, jsx, vue, css, less, scss, sass and styl files.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cqmetrics": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/dspinellis/cqmetrics",
+        "source": "https://github.com/dspinellis/cqmetrics",
+        "description": "Quality metrics for C code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "credo": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "elixir"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/rrrene/credo",
+        "source": "https://github.com/rrrene/credo",
+        "description": "A static code analysis tool with a focus on code consistency and teaching.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "crystal": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "crystal"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://crystal-lang.org",
+        "source": "https://github.com/crystal-lang/crystal",
+        "description": "The Crystal compiler has built-in linting functionality.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cwe_checker": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "GNU Lesser General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/fkie-cad/cwe_checker",
+        "source": "https://github.com/fkie-cad/cwe_checker",
+        "description": "cwe_checker finds vulnerable patterns in binary executables.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "cyclocomp": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "r"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/MangoTheCat/cyclocomp",
+        "source": "https://github.com/MangoTheCat/cyclocomp",
+        "description": "Quantifies the cyclomatic complexity of R functions / expressions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dagda": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "container"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/eliasgranderubio/dagda",
+        "source": "https://github.com/eliasgranderubio/dagda",
+        "description": "Perform static analysis of known vulnerabilities in docker images/containers.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dawnscanner": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [
+            "rails"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/thesp0nge/dawnscanner",
+        "source": "https://github.com/thesp0nge/dawnscanner",
+        "description": "A static analysis security scanner for ruby written web applications. It supports Sinatra, Padrino and Ruby on Rails frameworks.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dbcritic": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "sql"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD-3-Clause License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/channable/dbcritic",
+        "source": "https://github.com/channable/dbcritic",
+        "description": "dbcritic finds problems in a database schema, such as a missing primary key constraint in a table.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "deadcode": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/tsenart/deadcode",
+        "source": "https://github.com/tsenart/deadcode",
+        "description": "Finds unused code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "deadnix": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "nix"
+        ],
+        "licenses": [
+            "GPL-3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/astro/deadnix",
+        "source": "https://github.com/astro/deadnix",
+        "description": "Scan Nix files for dead code (unused variable bindings)",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dennis": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "translation"
+        ],
+        "licenses": [
+            "BSD-3-Clause"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/willkg/dennis",
+        "source": "https://github.com/willkg/dennis",
+        "description": "A set of utilities for working with PO files to ease development and improve quality.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "deno_lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "deno"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/denoland/deno_lint",
+        "source": "https://github.com/denoland/deno_lint",
+        "description": "Official linter for Deno.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dephpend": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mihaeu/dephpend",
+        "source": "https://github.com/mihaeu/dephpend",
+        "description": "Dependency analysis tool.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "deprecation-detector": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/sensiolabs-de/deprecation-detector",
+        "source": "https://github.com/sensiolabs-de/deprecation-detector",
+        "description": "Finds usages of deprecated (Symfony) code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "deptrac": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/sensiolabs-de/deptrac",
+        "source": "https://github.com/sensiolabs-de/deptrac",
+        "description": "Enforce rules for dependencies between software layers.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "detekt": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "kotlin"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://detekt.github.io/detekt",
+        "source": "https://github.com/detekt/detekt",
+        "description": "Static code analysis for Kotlin code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dialyxir": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "elixir"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/jeremyjh/dialyxir",
+        "source": "https://github.com/jeremyjh/dialyxir",
+        "description": "Mix tasks to simplify use of Dialyzer in Elixir projects.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dialyzer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "erlang"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.erlang.org/doc/man/dialyzer.html",
+        "source": "https://github.com/erlang/otp/tree/master/lib/dialyzer",
+        "description": "The DIALYZER, a DIscrepancy AnaLYZer for ERlang programs. Dialyzer is a static analysis tool that identifies software discrepancies,  such as definite type errors, code that has become dead or unreachable  because of programming error, and unnecessary tests,  in single Erlang modules or entire (sets of) applications.\nDialyzer starts its analysis from either debug-compiled BEAM bytecode  or from Erlang source code. The file and line number of a discrepancy  is reported along with an indication of what the discrepancy is about.  Dialyzer bases its analysis on the concept of success typings,  which allows for sound warnings (no false positives).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "ElixirConf 2016 - Dialyzer: Optimistic Type Checking for Erlang and Elixir by Jason Voegele",
+                "url": "https://www.youtube.com/watch?v=JT0ECYZ9FaQ"
+            },
+            {
+                "title": "Sean Cribbs - Chemanalysis: Dialyzing Elixir | Code BEAM SF 19",
+                "url": "https://www.youtube.com/watch?v=k4au7VioXNk"
+            },
+            {
+                "title": "Stavros Aronis - What does Dialyzer think about me? | Code BEAM STO 19",
+                "url": "https://www.youtube.com/watch?v=Nxsw1jRE2A4&t=709s"
+            }
+        ],
+        "wrapper": null
+    },
+    "diktat": {
+        "categories": [
+            "formatter",
+            "linter"
+        ],
+        "languages": [
+            "kotlin"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://analysis-dev.github.io/diktat",
+        "source": "https://github.com/diktat-static-analysis/diKTat",
+        "description": "Strict coding standard for Kotlin and a linter that detects and auto-fixes code smells.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dingo-hunter": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/nickng/dingo-hunter",
+        "source": "https://github.com/nickng/dingo-hunter",
+        "description": "Static analyser for finding deadlocks in Go.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dogsled": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/alexkohler/dogsled",
+        "source": "https://github.com/alexkohler/dogsled",
+        "description": "Finds assignments/declarations with too many blank identifiers.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dotenv-linter": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configfile"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://dotenv-linter.readthedocs.io/en/latest",
+        "source": "https://github.com/wemake-services/dotenv-linter",
+        "description": "Linting dotenv files like a charm.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dotenv-linter (Rust)": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configfile"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://dotenv-linter.github.io/#/",
+        "source": "https://github.com/dotenv-linter/dotenv-linter",
+        "description": "Lightning-fast linter for .env files. Written in Rust",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dupl": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mibk/dupl",
+        "source": "https://github.com/mibk/dupl",
+        "description": "Reports potentially duplicated code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "dylint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License / Apache 2.0 license"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.trailofbits.com/post/write-rust-lints-without-forking-clippy",
+        "source": "https://github.com/trailofbits/dylint",
+        "description": "A tool for running Rust lints from dynamic libraries. Dylint makes it easy for developers to maintain their own personal lint collections.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "effective_dart": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "dart"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pub.dev/packages/effective_dart",
+        "source": "https://github.com/tenhobi/effective_dart",
+        "description": "Linter rules corresponding to the guidelines in Effective Dart",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "electrolysis": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://kha.github.io/electrolysis",
+        "source": "https://github.com/Kha/electrolysis",
+        "description": "A tool for formally verifying Rust programs by transpiling them into definitions in the Lean theorem prover.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "elm-analyse": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "elm"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://stil4m.github.io/elm-analyse",
+        "source": "https://github.com/stil4m/elm-analyse",
+        "description": "A tool that allows you to analyse your Elm code, identify deficiencies and apply best practices.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "elm-review": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "elm"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://package.elm-lang.org/packages/jfmengels/elm-review/latest",
+        "source": "https://github.com/jfmengels/elm-review",
+        "description": "Analyzes whole Elm projects, with a focus on shareable and custom rules written in Elm that add guarantees the Elm compiler doesn't give you.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "elvis": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "erlang"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/inaka/elvis",
+        "source": "https://github.com/inaka/elvis",
+        "description": "Erlang Style Reviewer.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ember-template-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "template"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/ember-template-lint/ember-template-lint",
+        "source": "https://github.com/ember-template-lint/ember-template-lint",
+        "description": "Linter for Ember or Handlebars templates.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "errcheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/kisielk/errcheck",
+        "source": "https://github.com/kisielk/errcheck",
+        "description": "Check that error return values are used.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "errwrap": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/fatih/errwrap",
+        "source": "https://github.com/fatih/errwrap",
+        "description": "Wrap and fix Go errors with the new %w verb directive.  This tool analyzes fmt.Errorf() calls and reports calls that contain a verb directive that  is different than the new %w verb directive introduced in Go v1.13.  It's also capable of rewriting calls to use the new %w wrap verb directive.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "es6-plato": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/the-simian/es6-plato",
+        "source": "https://github.com/the-simian/es6-plato",
+        "description": "Visualize JavaScript (ES6) source complexity.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "escomplex": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/jared-stilwell/escomplex",
+        "source": "https://github.com/jared-stilwell/escomplex",
+        "description": "Software complexity analysis of JavaScript-family abstract syntax trees.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "exakat": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.exakat.io",
+        "source": "https://github.com/exakat/exakat",
+        "description": "An automated code reviewing engine for PHP.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "fb-contrib": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU Lesser General Public License v2.1"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://fb-contrib.sourceforge.net",
+        "source": "https://github.com/mebigfatguy/fb-contrib",
+        "description": "A plugin for FindBugs with additional bug detectors.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "fixit": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pypi.org/project/fixit",
+        "source": "https://github.com/Instagram/Fixit",
+        "description": "A framework for creating lint rules and corresponding auto-fixes for source code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Enforcing coding conventions using libCST and Fixit",
+                "url": "https://www.digitalernachschub.de/blog/enforcing-coding-conventions-using-libcst-and-fixit/"
+            }
+        ],
+        "wrapper": null
+    },
+    "flake8": {
+        "categories": [
+            "meta"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [
+            "meta"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/PyCQA/flake8",
+        "source": "https://github.com/PyCQA/flake8",
+        "description": "A wrapper around `pyflakes`, `pycodestyle` and `mccabe`.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "My Python Code Looks Ugly and Confusing - Help!",
+                "url": "https://www.youtube.com/watch?v=TDUf93vqq3g"
+            }
+        ],
+        "wrapper": null
+    },
+    "flawfinder": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://dwheeler.com/flawfinder/",
+        "source": "https://github.com/david-a-wheeler/flawfinder",
+        "description": "Finds possible security weaknesses.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "flay": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://ruby.sadi.st/Flay.html",
+        "source": "https://github.com/seattlerb/flay",
+        "description": "Flay analyzes code for structural similarities.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "flen": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/lafolle/flen",
+        "source": "https://github.com/lafolle/flen",
+        "description": "Get info on length of functions in a Go package.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "flint++": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "Boost Software License 1.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/JossWhittle/FlintPlusPlus",
+        "source": "https://github.com/JossWhittle/FlintPlusPlus",
+        "description": "Cross-platform, zero-dependency port of flint, a lint program for C++ developed and used at Facebook.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "flog": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://ruby.sadi.st/Flog.html",
+        "source": "https://github.com/seattlerb/flog",
+        "description": "Flog reports the most tortured code in an easy to read pain report. The higher the score, the more pain the code is in.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "flow": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://flow.org",
+        "source": "https://github.com/facebook/flow",
+        "description": "A static type checker for JavaScript.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "foodcritic": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.foodcritic.io",
+        "source": "https://github.com/foodcritic/foodcritic",
+        "description": "A lint tool that checks Chef cookbooks for common problems.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "forbidden-apis": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/policeman-tools/forbidden-apis",
+        "source": "https://github.com/policeman-tools/forbidden-apis",
+        "description": "Detects and forbids invocations of specific method/class/field (like reading from a text stream without a charset). Maven/Gradle/Ant compatible.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "gawk --lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "awk"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.gnu.org/software/gawk/manual/html_node/Options.html",
+        "source": "https://www.gnu.org/software/gawk/manual/html_node/Options.html",
+        "description": "Warns about constructs that are dubious or nonportable to other awk implementations.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "gherkin-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "gherkin"
+        ],
+        "licenses": [
+            "ISC License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/vsiakka/gherkin-lint",
+        "source": "https://github.com/vsiakka/gherkin-lint",
+        "description": "A linter for the Gherkin-Syntax written in Javascript.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "gixy": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configfile"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/yandex/gixy",
+        "source": "https://github.com/yandex/gixy",
+        "description": "A tool to analyze Nginx configuration. The main goal is to prevent misconfiguration and automate flaw detection.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "go tool vet --shadow": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD-3-Clause (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://golang.org/cmd/vet#hdr-Shadowed_variables",
+        "source": "https://github.com/golang/go/tree/master/src/cmd/vet",
+        "description": "Reports variables that may have been unintentionally shadowed.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "go vet": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD-3-Clause (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://golang.org/cmd/vet",
+        "source": "https://github.com/golang/go/tree/master/src/cmd/vet",
+        "description": "Examines Go source code and reports suspicious.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "go-consistent": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Quasilyte/go-consistent",
+        "source": "https://github.com/Quasilyte/go-consistent",
+        "description": "Analyzer that helps you to make your Go programs more consistent.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "go-critic": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/go-critic/go-critic",
+        "source": "https://github.com/go-critic/go-critic",
+        "description": "Go source code linter that maintains checks which are currently not implemented in other linters.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "go/ast": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD-3-Clause (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://golang.org/pkg/go/ast",
+        "source": "https://github.com/golang/go/tree/master/src/go/ast",
+        "description": "Package ast declares the types used to represent syntax trees for Go packages.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "gochecknoglobals": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/leighmcculloch/gochecknoglobals",
+        "source": "https://github.com/leighmcculloch/gochecknoglobals",
+        "description": "Checks that no globals are present.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "goconst": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/jgautheron/goconst",
+        "source": "https://github.com/jgautheron/goconst",
+        "description": "Finds repeated strings that could be replaced by a constant.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "gocyclo": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/fzipp/gocyclo",
+        "source": "https://github.com/fzipp/gocyclo",
+        "description": "Calculate cyclomatic complexities of functions in Go source code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "gofmt -s": {
+        "categories": [
+            "linter",
+            "formatter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD-3-Clause (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://golang.org/cmd/gofmt",
+        "source": "https://github.com/golang/go/tree/master/src/cmd/gofmt",
+        "description": "Checks if the code is properly formatted and could not be further simplified.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "goimports": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD-3-Clause (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pkg.go.dev/golang.org/x/tools/cmd/goimports",
+        "source": "https://github.com/golang/tools/tree/master/cmd/goimports",
+        "description": "Checks missing or unreferenced package imports.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "gokart": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [
+            "security"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/praetorian-inc/gokart",
+        "source": "https://github.com/praetorian-inc/gokart",
+        "description": "Golang security analysis with a focus on minimizing false positives. It is capable of tracing the source of variables and function arguments  to determine whether input sources are safe.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "golint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/golang/lint",
+        "source": "https://github.com/golang/lint",
+        "description": "Prints out coding style mistakes in Go source code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "goodpractice": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "r"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://mangothecat.github.io/goodpractice",
+        "source": "https://github.com/mangothecat/goodpractice",
+        "description": "Analyses the source code for R packages and provides best-practice recommendations.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "google-java-format": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/google/google-java-format",
+        "source": "https://github.com/google/google-java-format",
+        "description": "Google Style Reformat.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "goone": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go",
+            "sql"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/masibw/goone",
+        "source": "https://github.com/masibw/goone",
+        "description": "Finds N+1 queries (SQL calls in a for loop) in go code",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "goreporter": {
+        "categories": [
+            "meta"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [
+            "meta"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/360EntSecGroup-Skylar/goreporter",
+        "source": "https://github.com/360EntSecGroup-Skylar/goreporter",
+        "description": "Concurrently runs many linters and normalises their output to a report.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "goroutine-inspect": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 2-Clause \"Simplified\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/linuxerwang/goroutine-inspect",
+        "source": "https://github.com/linuxerwang/goroutine-inspect",
+        "description": "An interactive tool to analyze Golang goroutine dump.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "gosec (gas)": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://securego.io",
+        "source": "https://github.com/securego/gosec",
+        "description": "Inspects source code for security problems by scanning the Go AST.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "gotype": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "3-Clause BSD License + Patent Grant"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pkg.go.dev/golang.org/x/tools/cmd/gotype",
+        "source": "https://golang.org/x/tools/cmd/gotype",
+        "description": "Syntactic and semantic analysis similar to the Go compiler.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "graudit": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "asp",
+            "c",
+            "csharp",
+            "cpp",
+            "java",
+            "perl",
+            "php",
+            "python",
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.justanotherhacker.com",
+        "source": "https://github.com/wireghoul/graudit",
+        "description": "Grep rough audit - source code auditing tool.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "grunt-bootlint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "html"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/twbs/grunt-bootlint",
+        "source": "https://github.com/twbs/grunt-bootlint",
+        "description": "A Grunt wrapper for [Bootlint](https://github.com/twbs/bootlint), the HTML linter for Bootstrap projects.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "gulp-bootlint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "html"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/tschortsch/gulp-bootlint",
+        "source": "https://github.com/tschortsch/gulp-bootlint",
+        "description": "A gulp wrapper for [Bootlint](https://github.com/twbs/bootlint), the HTML linter for Bootstrap projects.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "haml-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "template"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/sds/haml-lint",
+        "source": "https://github.com/sds/haml-lint",
+        "description": "Tool for writing clean and consistent HAML.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "hegel": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://hegel.js.org",
+        "source": "https://github.com/JSMonk/hegel",
+        "description": "A static type checker for JavaScript with a bias on type inference and strong type systems.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "herbie": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Mozilla Public License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mcarton/rust-herbie-lint",
+        "source": "https://github.com/mcarton/rust-herbie-lint",
+        "description": "Adds warnings or errors to your crate when using a numerically unstable floating point expression.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "i-Code CNES for Fortran": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "fortran"
+        ],
+        "other": [],
+        "licenses": [
+            "Eclipse Public License 1.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/lequal/i-CodeCNES",
+        "source": "https://github.com/lequal/i-CodeCNES",
+        "description": "An open source static code analysis tool for Fortran 77, Fortran 90 and Shell.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "i-Code CNES for Shell": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "shell"
+        ],
+        "other": [],
+        "licenses": [
+            "Eclipse Public License 1.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/lequal/i-CodeCNES",
+        "source": "https://github.com/lequal/i-CodeCNES",
+        "description": "An open source static code analysis tool for Shell and Fortran (77 and 90).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "iblessing": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "mobile",
+            "security"
+        ],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.kitploit.com/2020/08/iblessing-ios-security-exploiting.html",
+        "source": "https://github.com/Soulghost/iblessing",
+        "description": "iblessing is an iOS security exploiting toolkit. It can be used for reverse engineering, binary analysis and vulnerability mining.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "imhotep": {
+        "categories": [
+            "meta"
+        ],
+        "languages": [
+            "javascript",
+            "python",
+            "ruby"
+        ],
+        "other": [
+            "buildtool",
+            "meta"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/justinabrahms/imhotep",
+        "source": "https://github.com/justinabrahms/imhotep",
+        "description": "Comment on commits coming into your repository and check for syntactic errors and general lint warnings.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "include-gardener": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "python",
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU Public License version 2 or greater"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/feddischson/include_gardener",
+        "source": "https://github.com/feddischson/include_gardener",
+        "description": "A multi-language static analyzer for C/C++/Obj-C/Python/Ruby to create a graph (in dot or graphml format) which shows all `#include` relations of a given set of files.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ineffassign": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/gordonklaus/ineffassign",
+        "source": "https://github.com/gordonklaus/ineffassign",
+        "description": "Detect ineffectual assignments in Go code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "interfacer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mvdan/interfacer",
+        "source": "https://github.com/mvdan/interfacer",
+        "description": "Suggest narrower interfaces that can be used.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "jedi": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://jedi.readthedocs.io/en/latest",
+        "source": "https://github.com/davidhalter/jedi",
+        "description": "Autocompletion/static analysis library for Python.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "jshint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://jshint.com/about",
+        "source": "https://github.com/jshint/jshint",
+        "description": "Detect errors and potential problems in JavaScript code and enforce your team's coding conventions.",
+        "discussion": "https://github.com/analysis-tools-dev/static-analysis/issues/223",
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "kics": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "ansible",
+            "configmanagement",
+            "container",
+            "kubernetes",
+            "security",
+            "terraform"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://kics.io/",
+        "source": "https://github.com/Checkmarx/kics",
+        "description": "Find security vulnerabilities, compliance issues, and infrastructure misconfigurations in your infrastructure-as-code. Supports Terraform, Kubernetes, Docker, AWS CloudFormation and Ansible",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "kmdr": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "shell"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://kmdr.sh",
+        "source": "https://github.com/ediardo/kmdr-cli",
+        "description": "CLI tool for learning commands from your terminal. kmdr delivers a break down of commands with every attribute explained.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ktlint": {
+        "categories": [
+            "formatter",
+            "linter"
+        ],
+        "languages": [
+            "kotlin"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://ktlint.github.io",
+        "source": "https://github.com/shyiko/ktlint",
+        "description": "An anti-bikeshedding Kotlin linter with built-in formatter.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "kube-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement",
+            "container",
+            "kubernetes"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/viglesiasce/kube-lint",
+        "source": "https://github.com/viglesiasce/kube-lint",
+        "description": "A linter for Kubernetes resources with a customizable rule set. You define a list of rules that you would like to validate against your  resources and kube-lint will evaluate those rules against them.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "kube-linter": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement",
+            "container",
+            "kubernetes"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/stackrox/kube-linter",
+        "source": "https://github.com/stackrox/kube-linter",
+        "description": "KubeLinter is a static analysis tool that checks Kubernetes YAML files  and Helm charts to ensure the applications represented in them adhere to best practices. ",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "kube-score": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "container"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://kube-score.com",
+        "source": "https://github.com/zegl/kube-score",
+        "description": "Static code analysis of your Kubernetes object definitions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "kubeval": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement",
+            "container",
+            "kubernetes"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://kubeval.instrumenta.dev",
+        "source": "https://github.com/instrumenta/kubeval",
+        "description": "Validates your Kubernetes configuration files and supports multiple Kubernetes versions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "lacheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "latex"
+        ],
+        "licenses": [
+            "GPL"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.ctan.org/pkg/lacheck",
+        "source": "https://www.ctan.org/tex-archive/support/lacheck",
+        "description": "A tool for finding common mistakes in LaTeX documents.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "languagetool": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "writing"
+        ],
+        "licenses": [
+            "GNU Lesser General Public License v2.1"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://languagetool.org",
+        "source": "https://github.com/languagetool-org/languagetool",
+        "description": "Style and grammar checker for 25+ languages. It finds many errors that a simple spell checker cannot detect.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "larastan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/nunomaduro/larastan",
+        "source": "https://github.com/nunomaduro/larastan",
+        "description": "Adds static analysis to Laravel improving developer productivity and code quality. It is a wrapper around PHPStan.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "laser": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU Affero General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/michaeledgar/laser",
+        "source": "https://github.com/michaeledgar/laser",
+        "description": "Static analysis and style linter for Ruby code.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "dart"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/passsy/dart-lint",
+        "source": "https://github.com/passsy/dart-lint",
+        "description": "An opinionated, community-driven set of lint rules for Dart and Flutter projects. Like pedantic but stricter",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "linter": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "scala"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/HairyFotr/linter",
+        "source": "https://github.com/HairyFotr/linter",
+        "description": "Linter is a Scala static analysis compiler plugin which adds compile-time checks for various possible bugs, inefficiencies, and style problems.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "linter-rust": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/AtomLinter/linter-rust",
+        "source": "https://github.com/AtomLinter/linter-rust",
+        "description": "Linting your Rust-files in Atom, using rustc and cargo.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "lintian": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "package"
+        ],
+        "licenses": [
+            "GNU General Public License v2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://lintian.debian.org",
+        "source": "https://github.com/Debian/lintian",
+        "description": "Static analysis tool for Debian packages.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "lintr": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "r"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/jimhester/lintr",
+        "source": "https://github.com/jimhester/lintr",
+        "description": "Static Code Analysis for R.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "linty fresh": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/lyft/linty_fresh",
+        "source": "https://github.com/lyft/linty_fresh",
+        "description": "Parse lint errors and report them to Github as comments on a pull request.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "lizard": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "go",
+            "java",
+            "javascript",
+            "lua",
+            "objectivec",
+            "php",
+            "python",
+            "ruby",
+            "rust",
+            "scala",
+            "swift",
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/terryyin/lizard",
+        "source": "https://github.com/terryyin/lizard",
+        "description": "Lizard is an extensible Cyclomatic Complexity Analyzer for many programming languages  including C/C++ (doesn't require all the header files or Java imports).  It also does copy-paste detection (code clone detection/code duplicate detection) and many other forms of static code analysis. Counts lines of code without comments, CCN (cyclomatic complexity number), token count of functions, parameter count of functions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "lll": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/walle/lll",
+        "source": "https://github.com/walle/lll",
+        "description": "Report long lines.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "lockfile-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "nodejs",
+            "security"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/lirantal/lockfile-lint",
+        "source": "https://github.com/lirantal/lockfile-lint",
+        "description": "Lint an npm or yarn lockfile to analyze and detect security issues",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "luacheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "lua"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mpeterv/luacheck",
+        "source": "https://github.com/mpeterv/luacheck",
+        "description": "A tool for linting and static analysis of Lua code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "lualint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "lua"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/philips/lualint",
+        "source": "https://github.com/philips/lualint",
+        "description": "lualint performs luac-based static analysis of global variable usage in Lua source code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "maligned": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mdempsky/maligned",
+        "source": "https://github.com/mdempsky/maligned",
+        "description": "Detect structs that would take less memory if their fields were sorted.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "markdownlint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "markdown"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/DavidAnson/markdownlint",
+        "source": "https://github.com/DavidAnson/markdownlint",
+        "description": "Node.js -based style checker and lint tool for Markdown/CommonMark files.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "mccabe": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pypi.org/project/mccabe",
+        "source": "https://github.com/PyCQA/mccabe",
+        "description": "Check McCabe complexity.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "mcsema": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "AGPL-3.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/lifting-bits/mcsema",
+        "source": "https://github.com/lifting-bits/mcsema",
+        "description": "Framework for lifting x86, amd64, aarch64, sparc32, and sparc64 program binaries to LLVM bitcode. It translates (\"lifts\") executable binaries from native machine code to LLVM bitcode, which is very useful for performing program analysis methods.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "mdformat": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [],
+        "other": [
+            "markdown"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://mdformat.rtfd.io",
+        "source": "https://github.com/executablebooks/mdformat",
+        "description": "CommonMark compliant Markdown formatter",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "mdl": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "markdown"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mivok/markdownlint",
+        "source": "https://github.com/mivok/markdownlint",
+        "description": "A tool to check Markdown files and flag style issues.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "metadata-json-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement",
+            "puppet"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/voxpupuli/metadata-json-lint",
+        "source": "https://github.com/voxpupuli/metadata-json-lint",
+        "description": "Tool to check the validity of Puppet metadata.json files.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "misspell": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/client9/misspell",
+        "source": "https://github.com/client9/misspell",
+        "description": "Finds commonly misspelled English words.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "misspell-fixer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "writing"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/vlajos/misspell-fixer",
+        "source": "https://github.com/vlajos/misspell-fixer",
+        "description": "Quick tool for fixing common misspellings, typos in source code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "mlint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "matlab"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://mathworks.com/help/matlab/ref/mlint.html",
+        "source": null,
+        "description": "Check MATLAB code files for possible problems.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "multilint": {
+        "categories": [
+            "meta"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [
+            "meta"
+        ],
+        "licenses": [
+            "ISC License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/adamchainz/multilint",
+        "source": "https://github.com/adamchainz/multilint",
+        "description": "A wrapper around `flake8`, `isort` and `modernize`.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "mypy": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.mypy-lang.org",
+        "source": "https://github.com/python/mypy",
+        "description": "A static type checker that aims to combine the benefits of duck typing and static typing, frequently used with [MonkeyType](https://github.com/Instagram/MonkeyType).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "mythril": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "smart-contracts"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/ConsenSys/mythril",
+        "source": "https://github.com/ConsenSys/mythril",
+        "description": "A symbolic execution framework with batteries included, can be used to find and exploit vulnerabilities in smart contracts automatically.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "The Ether Wars: Exploits, counter exploits and honeypots - Bernhard Mueller, DEF CON 27 Conference",
+                "url": "https://www.youtube.com/watch?v=Qd9ubry-c_M"
+            },
+            {
+                "title": "Smashing Ethereum Smart Contracts for Fun and ACTUAL Profit - Bernhard Mueller",
+                "url": "https://www.youtube.com/watch?v=iqf6epACgds"
+            }
+        ],
+        "wrapper": null
+    },
+    "nakedret": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/alexkohler/nakedret",
+        "source": "https://github.com/alexkohler/nakedret",
+        "description": "Finds naked returns.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "nargs": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/alexkohler/nargs",
+        "source": "https://github.com/alexkohler/nargs",
+        "description": "Finds unused arguments in function declarations.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "nimfmt": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "nim"
+        ],
+        "other": [],
+        "licenses": [
+            "GPL-3.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/FedericoCeratto/nimfmt",
+        "source": "https://github.com/FedericoCeratto/nimfmt",
+        "description": "Nim code formatter / linter / style checker",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "njsscan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "nodejs",
+            "security"
+        ],
+        "licenses": [
+            "LGPL-2.1 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://opensecurity.in",
+        "source": "https://github.com/ajinabraham/njsscan",
+        "description": "A static application testing (SAST) tool that can find insecure code patterns in your node.js applications using simple pattern matcher from libsast and syntax-aware semantic code pattern search tool semgrep.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "oclint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "objectivec"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD-3-Clause (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://oclint.org",
+        "source": "https://github.com/oclint/oclint",
+        "description": "A static source code analysis tool to improve quality and reduce defects for C, C++ and Objective-C.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ocular": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "go",
+            "java",
+            "javascript",
+            "jsp",
+            "python",
+            "scala",
+            "swift"
+        ],
+        "other": [
+            "security"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.shiftleft.io/ocular/",
+        "source": null,
+        "description": "Enables code auditors and security teams to interactively investigate their unique code bases  to find business logic flaws and technical vulnerabilities that traditional SASTs cannot. This is done by enabling the analyst to write their own custom queries. Can find hard-coded secrets, authentication issues, and malicious code like rootkits and backdoors.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "oelint-adv": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "embedded"
+        ],
+        "licenses": [
+            "BSD 2-Clause \"Simplified\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/priv-kweihmann/oelint-adv",
+        "source": "https://github.com/priv-kweihmann/oelint-adv",
+        "description": "Linter for bitbake recipes used in open-embedded and YOCTO",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "paprika": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "mobile"
+        ],
+        "licenses": [
+            "GNU Affero General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/GeoffreyHecht/paprika",
+        "source": "https://github.com/GeoffreyHecht/paprika",
+        "description": "A toolkit to detect some code smells in analyzed Android applications.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "parallel-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
+        "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
+        "description": "This tool checks syntax of PHP files faster than serial check with a fancier output.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "parasoft": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://www.parasoft.com/",
+        "source": null,
+        "description": "Automated Software Testing Solutions for unit-, API-, and web UI testing. Complies with MISRA, OWASP, and others.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "pdepend": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pdepend.org",
+        "source": "https://github.com/pdepend/pdepend",
+        "description": "Calculates software metrics like cyclomatic complexity for PHP code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "pelusa": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/codegram/pelusa",
+        "source": "https://github.com/codegram/pelusa",
+        "description": "Static analysis Lint-type tool to improve your OO Ruby code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "pfff": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "erlang",
+            "haskell",
+            "java",
+            "javascript",
+            "php",
+            "python",
+            "rust"
+        ],
+        "other": [
+            "css",
+            "html"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/facebookarchive/pfff/wiki/Main",
+        "source": "https://github.com/returntocorp/pfff",
+        "description": "Facebook's tools for code analysis, visualizations, or style-preserving source transformation for many languages.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "phan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/phan/phan/wiki",
+        "source": "https://github.com/etsy/phan",
+        "description": "A modern static analyzer from etsy.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "php-speller": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mekras/php-speller",
+        "source": "https://github.com/mekras/php-speller",
+        "description": "PHP spell check library.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "php7cc": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/sstalle/php7cc",
+        "source": "https://github.com/sstalle/php7cc",
+        "description": "PHP 7 Compatibility Checker.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "php7mar": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Alexia/php7mar",
+        "source": "https://github.com/Alexia/php7mar",
+        "description": "Assist developers in porting their code quickly to PHP 7.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "phpDocumentor": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.phpdoc.org",
+        "source": "https://github.com/phpDocumentor/phpDocumentor",
+        "description": "Analyzes PHP source code to generate documentation.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "phpca": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/wapmorgan/PhpCodeAnalyzer",
+        "source": "https://github.com/wapmorgan/PhpCodeAnalyzer",
+        "description": "Finds usage of non-built-in extensions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "phpcpd": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/sebastianbergmann/phpcpd",
+        "source": "https://github.com/sebastianbergmann/phpcpd",
+        "description": "Copy/Paste Detector for PHP code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "phpdcd": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/sebastianbergmann/phpdcd",
+        "source": "https://github.com/sebastianbergmann/phpdcd",
+        "description": "Dead Code Detector (DCD) for PHP code.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "phpdoc-to-typehint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/dunglas/phpdoc-to-typehint",
+        "source": "https://github.com/dunglas/phpdoc-to-typehint",
+        "description": "Add scalar type hints and return types to existing PHP projects using PHPDoc annotations.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "phploc": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/sebastianbergmann/phploc",
+        "source": "https://github.com/sebastianbergmann/phploc",
+        "description": "A tool for quickly measuring the size and analyzing the structure of a PHP project.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "phpmnd": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/povils/phpmnd",
+        "source": "https://github.com/povils/phpmnd",
+        "description": "Helps to detect magic numbers.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "phpqa - jakzal": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/jakzal/phpqa",
+        "source": "https://github.com/jakzal/phpqa",
+        "description": "Many tools for PHP static analysis in one container.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "phpqa - jmolivas": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/jmolivas/phpqa",
+        "source": "https://github.com/jmolivas/phpqa",
+        "description": "PHPQA all-in-one Analyzer CLI tool.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "phpsa": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/ovr/phpsa",
+        "source": "https://github.com/ovr/phpsa",
+        "description": "Static analysis tool for PHP.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "plato": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/es-analysis/plato",
+        "source": "https://github.com/es-analysis/plato",
+        "description": "Visualize JavaScript source complexity.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "portlint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "buildtool",
+            "make"
+        ],
+        "licenses": [
+            "BSD License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.freebsd.org/cgi/man.cgi?query=portlint&sektion=1&manpath=FreeBSD+8.1-RELEASE+and+Ports",
+        "source": "https://www.freebsd.org/cgi/man.cgi?query=portlint&sektion=1&manpath=FreeBSD+8.1-RELEASE+and+Ports",
+        "description": "A verifier for FreeBSD and DragonFlyBSD port directories.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "prae": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/teenjuna/prae",
+        "source": "https://github.com/teenjuna/prae",
+        "description": "Provides a convenient macro that allows you to generate type wrappers  that promise to always uphold arbitrary invariants that you specified. ",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "pre-commit": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "java",
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pre-commit.com",
+        "source": "https://github.com/pre-commit/pre-commit",
+        "description": "A framework for managing and maintaining multi-language pre-commit hooks.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "prealloc": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/alexkohler/prealloc",
+        "source": "https://github.com/alexkohler/prealloc",
+        "description": "Finds slice declarations that could potentially be preallocated.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "proselint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "writing"
+        ],
+        "licenses": [
+            "BSD-3-Clause"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://proselint.com",
+        "source": "https://github.com/amperser/proselint",
+        "description": "A linter for English prose with a focus on writing style instead of grammar.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "prospector": {
+        "categories": [
+            "meta"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [
+            "meta"
+        ],
+        "licenses": [
+            "GNU General Public License v2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/PyCQA/prospector",
+        "source": "https://github.com/PyCQA/prospector",
+        "description": "A wrapper around `pylint`, `pep8`, `mccabe` and others.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "protolint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "protobuf"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/yoheimuta/protolint",
+        "source": "https://github.com/yoheimuta/protolint",
+        "description": "Pluggable linter and fixer to enforce Protocol Buffer style and conventions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "py-find-injection": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/uber/py-find-injection",
+        "source": "https://github.com/uber/py-find-injection",
+        "description": "Find SQL injection vulnerabilities in Python code.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "pyanalyze": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pyanalyze.readthedocs.io/en/latest/",
+        "source": "https://github.com/quora/pyanalyze",
+        "description": "A tool for programmatically detecting common mistakes in Python code, such as references to undefined variables and type errors. It can be extended to add additional rules and perform checks specific to particular functions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "pycodestyle": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pycodestyle.pycqa.org/en/latest",
+        "source": "https://github.com/PyCQA/pycodestyle",
+        "description": "(Formerly `pep8`) Check Python code against some of the style conventions in PEP 8.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "pydocstyle": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://www.pydocstyle.org",
+        "source": "https://github.com/PyCQA/pydocstyle",
+        "description": "Check compliance with Python docstring conventions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "pyflakes": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pypi.org/project/pyflakes",
+        "source": "https://github.com/pyflakes/pyflakes",
+        "description": "Check Python source files for errors.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "pylama": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript",
+            "python"
+        ],
+        "other": [
+            "meta"
+        ],
+        "licenses": [
+            "LGPL-3.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://klen.github.io/pylama/",
+        "source": "https://github.com/klen/pylama",
+        "description": "Code audit tool for Python and JavaScript. Wraps pycodestyle, pydocstyle, PyFlakes, Mccabe, Pylint, and more",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "pylint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://pylint.pycqa.org/en/latest",
+        "source": "https://github.com/PyCQA/pylint",
+        "description": "Looks for programming errors, helps enforcing a coding standard and sniffs for some code smells. It additionally includes `pyreverse` (an UML diagram generator) and `symilar` (a similarities checker).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Pylint Tutorial – How to Write Clean Python",
+                "url": "https://www.youtube.com/watch?v=fFY5103p5-c"
+            }
+        ],
+        "wrapper": null
+    },
+    "pyre-check": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pyre-check.org",
+        "source": "https://github.com/facebook/pyre-check",
+        "description": "A fast, scalable type checker for large Python codebases.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "pyright": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Microsoft/pyright",
+        "source": "https://github.com/Microsoft/pyright",
+        "description": "Static type checker for Python, created to address gaps in existing tools like mypy.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "pyroma": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/regebro/pyroma",
+        "source": "https://github.com/regebro/pyroma",
+        "description": "Rate how well a Python project complies with the best practices of the Python packaging ecosystem, and list issues that could be improved.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "pytype": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://google.github.io/pytype",
+        "source": "https://github.com/google/pytype",
+        "description": "A static type analyzer for Python code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "qark": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "mobile"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/linkedin/qark",
+        "source": "https://github.com/linkedin/qark",
+        "description": "Tool to look for several security related Android application vulnerabilities.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "quality": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [
+            "ci"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/apiology/quality",
+        "source": "https://github.com/apiology/quality",
+        "description": "Runs quality checks on your code using community tools, and makes sure your numbers don't get any worse over time.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "qulice": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "java"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.qulice.com",
+        "source": "https://github.com/teamed/qulice",
+        "description": "Combines a few (pre-configured) static analysis tools (checkstyle, PMD, Findbugs, ...).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "radon": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://radon.readthedocs.io/en/latest",
+        "source": "https://github.com/rubik/radon",
+        "description": "A Python tool that computes various metrics from the source code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "rails_best_practices": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://rails-bestpractices.com",
+        "source": "https://github.com/flyerhzm/rails_best_practices",
+        "description": "A code metric tool for Rails projects",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "redex": {
+        "categories": [
+            "optimizer"
+        ],
+        "languages": [],
+        "other": [
+            "mobile"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://fbredex.com",
+        "source": "https://github.com/facebook/redex",
+        "description": "Redex provides a framework for reading, writing, and analyzing .dex files, and a set of optimization passes  that use this framework to improve the bytecode. An APK optimized by Redex should be smaller and faster.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "droidcon SF 2017 - Redex, Your Build, And You",
+                "url": "https://www.youtube.com/watch?v=vtxJvJj6gSE"
+            },
+            {
+                "title": "Optimizing Android bytecode with ReDex",
+                "url": "https://engineering.fb.com/android/optimizing-android-bytecode-with-redex/"
+            },
+            {
+                "title": "~",
+                "url": "https://www.youtube.com/watch?v=h_Gkl5eAdc4"
+            }
+        ],
+        "wrapper": null
+    },
+    "reek": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/troessner/reek",
+        "source": "https://github.com/troessner/reek",
+        "description": "Code smell detector for Ruby.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "relint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "dotnet",
+            "c",
+            "cpp",
+            "java",
+            "javascript",
+            "jsx",
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/codingjoe/relint",
+        "source": "https://github.com/codingjoe/relint",
+        "description": "A static file linter that allows you to write custom rules using regular expressions (RegEx).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "remark-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "markdown"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://remark.js.org",
+        "source": "https://github.com/remarkjs/remark-lint",
+        "description": "Pluggable Markdown code style linter written in JavaScript.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "retire.js": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://retirejs.github.io/retire.js",
+        "source": "https://github.com/RetireJS/retire.js",
+        "description": "Scanner detecting the use of JavaScript libraries with known vulnerabilities.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "revive": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://revive.run",
+        "source": "https://github.com/mgechev/revive",
+        "description": "Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "rpmlint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "package"
+        ],
+        "licenses": [
+            "GNU General Public License v2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/rpm-software-management/rpmlint",
+        "source": "https://github.com/rpm-software-management/rpmlint",
+        "description": "Tool for checking common errors in rpm packages.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "ruby-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "Mozilla Public License, version 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://code.yorickpeterse.com/ruby-lint/latest",
+        "source": "https://gitlab.com/yorickpeterse/ruby-lint",
+        "description": "Static code analysis for Ruby.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "rubycritic": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/whitesmith/rubycritic",
+        "source": "https://github.com/whitesmith/rubycritic",
+        "description": "A Ruby code quality reporter.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "rufo": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "ruby"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/ruby-formatter/rufo",
+        "source": "https://github.com/ruby-formatter/rufo",
+        "description": "An opinionated ruby formatter, intended to be used via the command line as a text-editor plugin, to autoformat files on save or on demand.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "rust-analyzer": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://rust-analyzer.github.io",
+        "source": "https://github.com/rust-analyzer/rust-analyzer",
+        "description": "Supports functionality such as 'goto definition', type inference, symbol search, reformatting, and code completion, and enables renaming and refactorings.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "rust-audit": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Shnatsel/rust-audit",
+        "source": "https://github.com/Shnatsel/rust-audit",
+        "description": "Audit Rust binaries for known bugs or security vulnerabilities. This works by embedding data about the dependency tree (Cargo.lock) in JSON format into a dedicated linker section of the compiled executable.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "rustfix": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/rust-lang/rustfix",
+        "source": "https://github.com/rust-lang/rustfix",
+        "description": "Read and apply the suggestions made by rustc (and third-party lints, like those offered by clippy).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "rustfmt": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/rust-lang/rustfmt",
+        "source": "https://github.com/rust-lang/rustfmt",
+        "description": "A tool for formatting Rust code according to style guidelines.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "safesql": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/stripe/safesql",
+        "source": "https://github.com/stripe/safesql",
+        "description": "Static analysis tool for Golang that protects against SQL injections.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "sass-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "css"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/sasstools/sass-lint",
+        "source": "https://github.com/sasstools/sass-lint",
+        "description": "A Node-only Sass linter for both sass and scss syntax.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "scan-build": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "Llvm release license"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://clang-analyzer.llvm.org/scan-build.html",
+        "source": "https://clang-analyzer.llvm.org/scan-build.html",
+        "description": "Analyzes C/C++ code using LLVM at compile-time.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "scapegoat": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "scala"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/sksamuel/scapegoat",
+        "source": "https://github.com/sksamuel/scapegoat",
+        "description": "Scala compiler plugin for static code analysis.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "scorecard": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "security"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/ossf/scorecard",
+        "source": "https://github.com/ossf/scorecard",
+        "description": "Security Scorecards - Security health metrics for Open Source",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "scsslint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "css"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/brigade/scss-lint",
+        "source": "https://github.com/brigade/scss-lint",
+        "description": "Linter for SCSS files.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "sh": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "shell"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD-3-Clause License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://pkg.go.dev/mvdan.cc/sh/v3",
+        "source": "https://github.com/mvdan/sh",
+        "description": "A shell parser, formatter, and interpreter with bash support; includes shfmt",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "shellcheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "shell"
+        ],
+        "other": [],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.shellcheck.net",
+        "source": "https://github.com/koalaman/shellcheck",
+        "description": "ShellCheck, a static analysis tool that gives warnings and suggestions for bash/sh shell scripts.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "shellharden": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "shell"
+        ],
+        "other": [],
+        "licenses": [
+            "MPL-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/anordal/shellharden",
+        "source": "https://github.com/anordal/shellharden",
+        "description": "A syntax highlighter and a tool to semi-automate the rewriting of scripts to ShellCheck conformance, mainly focused on quoting.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "shipshape": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "java",
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/google/shipshape",
+        "source": "https://github.com/google/shipshape",
+        "description": "Static program analysis platform that allows custom analyzers to plug in through a common interface.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "shisho": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [
+            "terraform"
+        ],
+        "licenses": [
+            "AGPL-3.0"
+        ],
+        "types": [
+            "cli",
+            "service"
+        ],
+        "homepage": "https://docs.shisho.dev/",
+        "source": "https://github.com/flatt-security/shisho",
+        "description": "A lightweight static code analyzer designed for developers and security teams. It allows you to analyze and transform source code with an intuitive DSL similar to sed, but for code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "slim-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "template"
+        ],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/sds/slim-lint",
+        "source": "https://github.com/sds/slim-lint",
+        "description": "Configurable tool for analyzing Slim templates.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "slither": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [],
+        "other": [
+            "smart-contracts"
+        ],
+        "licenses": [
+            "GNU Affero General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/trailofbits/slither",
+        "source": "https://github.com/trailofbits/slither",
+        "description": "Static analysis framework that runs a suite of vulnerability detectors, prints visual information about contract details, and provides an API to easily write custom analyses.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "sobelow": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "elixir"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/nccgroup/sobelow",
+        "source": "https://github.com/nccgroup/sobelow",
+        "description": "Security-focused static analysis for the Phoenix Framework.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "solhint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "smart-contracts"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://protofire.github.io/solhint",
+        "source": "https://github.com/protofire/solhint",
+        "description": "Solhint is an open source project created by https://protofire.io. Its goal is to provide a linting utility for Solidity code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "solium": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "smart-contracts"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://ethlint.readthedocs.io/en/latest",
+        "source": "https://github.com/duaraghav8/Solium",
+        "description": "Solium is a linter to identify and fix style and security issues in Solidity smart contracts.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "splint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://splint.org",
+        "source": "https://github.com/ravenexp/splint",
+        "description": "Annotation-assisted static program checker.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "sqlcheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "sql"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/jarulraj/sqlcheck",
+        "source": "https://github.com/jarulraj/sqlcheck",
+        "description": "Automatically identify anti-patterns in SQL queries.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "sqlint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "sql"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/purcell/sqlint",
+        "source": "https://github.com/purcell/sqlint",
+        "description": "Simple SQL linter.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "sqlvet": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go",
+            "sql"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/houqp/sqlvet",
+        "source": "https://github.com/houqp/sqlvet",
+        "description": "Performs static analysis on raw SQL queries in your Go code base to surface potential runtime errors. It checks for SQL syntax error, identifies unsafe queries that could potentially lead to SQL injections makes sure column count matches value count in INSERT statements and validates table- and column names.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "squawk": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "sql"
+        ],
+        "other": [],
+        "licenses": [
+            "GPL-3.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://squawkhq.com",
+        "source": "https://github.com/sbdchd/squawk",
+        "description": "Linter for PostgreSQL, focused on migrations. Prevents unexpected downtime caused by database migrations and encourages best practices around Postgres schemas and SQL.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "standard": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [
+            "nodejs"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://standardjs.com",
+        "source": "https://github.com/standard/standard",
+        "description": "An npm module that checks for Javascript Styleguide issues.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "staticcheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://staticcheck.io",
+        "source": "https://github.com/dominikh/go-tools",
+        "description": "Go static analysis that specialises in finding bugs, simplifying code and improving performance.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "statix": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "nix"
+        ],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://git.peppe.rs/languages/statix/about/",
+        "source": "https://github.com/nerdypepper/statix",
+        "description": "Lints and suggestions for the Nix programming language. \"statix check\" highlights antipatterns in Nix code. \"statix fix\" can fix several such occurrences.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "structcheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "GPL-3.0-only (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://gitlab.com/opennota/check",
+        "source": "https://gitlab.com/opennota/check",
+        "description": "Find unused struct fields.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "structslop": {
+        "categories": [
+            "linter",
+            "formatter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/orijtech/structslop",
+        "source": "https://github.com/orijtech/structslop",
+        "description": "Static analyzer for Go that recommends struct field rearrangements to provide for maximum space/allocation efficiency",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "styler": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "r"
+        ],
+        "other": [],
+        "licenses": [
+            "GPL-3"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://styler.r-lib.org",
+        "source": "https://github.com/r-lib/styler",
+        "description": "Formatting of R source code files and pretty-printing of R code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "svls": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "verilog"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/dalance/svls",
+        "source": "https://github.com/dalance/svls",
+        "description": "A Language Server Protocol implementation for Verilog and SystemVerilog, including lint capabilities.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "sysdig": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "container"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://sysdig.com/",
+        "source": null,
+        "description": "A secure DevOps platform for cloud and container forensics. Built on an open source stack, Sysdig provides Docker image scanning and created Falco, the open standard for runtime threat detection for containers, Kubernetes and cloud. ",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Run confidently with secure DevOps",
+                "url": "https://www.youtube.com/watch?v=KXfZWprVr0w"
+            }
+        ],
+        "wrapper": null
+    },
+    "tclchecker": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "tcl"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/ActiveState/tdk/blob/master/docs/3.0/TDK_3.0_Checker.txt",
+        "source": "https://github.com/ActiveState/tdk/blob/master/docs/3.0/TDK_3.0_Checker.txt",
+        "description": "A static syntax analysis module (as part of [TDK](https://github.com/ActiveState/tdk)).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "tern": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://ternjs.net",
+        "source": "https://github.com/ternjs/tern",
+        "description": "A JavaScript code analyzer for deep, cross-editor language support.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "terraform-compliance": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://terraform-compliance.com",
+        "source": "https://github.com/eerkunt/terraform-compliance",
+        "description": "A lightweight, compliance- and security focused, BDD test framework against Terraform.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "terrascan": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/cesar-rodriguez/terrascan",
+        "source": "https://github.com/cesar-rodriguez/terrascan",
+        "description": "Collection of security and best practice tests for static code analysis of Terraform templates.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "test": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD-3-Clause (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "http://golang.org/pkg/testing",
+        "source": "http://golang.org/pkg/testing",
+        "description": "Show location of test failures from the stdlib testing module.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "tflint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement"
+        ],
+        "licenses": [
+            "Mozilla Public License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/wata727/tflint",
+        "source": "https://github.com/wata727/tflint",
+        "description": "A Terraform linter for detecting errors that can not be detected by `terraform plan`.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "tfsec": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "configmanagement",
+            "security"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/tfsec/tfsec",
+        "source": "https://github.com/tfsec/tfsec",
+        "description": "Terraform static analysis tool that prevents potential security issues by checking cloud misconfigurations at build time and directly integrates with the HCL parser for better results. Checks for violations of AWS, Azure and GCP security best practice recommendations.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "todocheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "csharp",
+            "cpp",
+            "go",
+            "groovy",
+            "java",
+            "javascript",
+            "php",
+            "python",
+            "r",
+            "rust",
+            "scala",
+            "shell",
+            "swift",
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/preslavmihaylov/todocheck",
+        "source": "https://github.com/preslavmihaylov/todocheck",
+        "description": "Linter for integrating annotated TODOs with your issue trackers",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "trivy": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript",
+            "php",
+            "ruby",
+            "rust"
+        ],
+        "other": [
+            "container",
+            "nodejs"
+        ],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/aquasecurity/trivy",
+        "source": "https://github.com/aquasecurity/trivy",
+        "description": "A Simple and Comprehensive Vulnerability Scanner for Containers and other Artifacts, Suitable for CI. Trivy detects vulnerabilities of OS packages (Alpine, RHEL, CentOS, etc.) and application dependencies (Bundler, Composer, npm, yarn, etc.). Checks containers and filesystems.\n",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "trunk": {
+        "categories": [
+            "formatter",
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp",
+            "go",
+            "java",
+            "javascript",
+            "python",
+            "ruby",
+            "rust",
+            "typescript"
+        ],
+        "other": [
+            "ansible",
+            "cloudformation",
+            "dockerfile",
+            "markdown",
+            "protobuf",
+            "terraform"
+        ],
+        "licenses": [
+            "proprietary"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://trunk.io",
+        "source": "https://github.com/trunk-io/",
+        "description": "Modern repositories include many technologies, each with its own set of linters. With 30+ linters and counting, Trunk makes it dead-simple to identify, install, configure, and run the right linters, static analyzers, and formatters for all your repos.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": [
+            {
+                "title": "Trunk GitHub Action",
+                "url": "https://github.com/trunk-io/trunk-action"
+            },
+            {
+                "title": "Community Slack Channel",
+                "url": "https://slack.trunk.io"
+            }
+        ],
+        "wrapper": null
+    },
+    "tslint-clean-code": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "Other"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://www.npmjs.com/package/tslint-clean-code",
+        "source": "https://github.com/Glavin001/tslint-clean-code",
+        "description": "A set of TSLint rules inspired by the Clean Code handbook.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "tslint-microsoft-contrib": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "typescript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/Microsoft/tslint-microsoft-contrib",
+        "source": "https://github.com/Microsoft/tslint-microsoft-contrib",
+        "description": "A set of tslint rules for static code analysis of TypeScript projects maintained by Microsoft.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "tsqllint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "sql"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/tsqllint/tsqllint",
+        "source": "https://github.com/tsqllint/tsqllint",
+        "description": "T-SQL-specific linter.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "twig-lint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "php"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/asm89/twig-lint",
+        "source": "https://github.com/asm89/twig-lint",
+        "description": "twig-lint is a lint tool for your twig files.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "unconvert": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mdempsky/unconvert",
+        "source": "https://github.com/mdempsky/unconvert",
+        "description": "Detect redundant type conversions.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "unimport": {
+        "categories": [
+            "linter",
+            "formatter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://unimport.hakancelik.dev",
+        "source": "https://github.com/hakancelik96/unimport",
+        "description": "A linter, formatter for finding and removing unused import statements.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "unparam": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "BSD 3-Clause \"New\" or \"Revised\" License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/mvdan/unparam",
+        "source": "https://github.com/mvdan/unparam",
+        "description": "Find unused function parameters.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "vale": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "writing"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://docs.errata.ai/vale/about",
+        "source": "https://github.com/errata-ai/vale",
+        "description": "A syntax-aware linter for prose built with speed and extensibility in mind.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "varcheck": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "GPL-3.0-only (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://gitlab.com/opennota/check",
+        "source": "https://gitlab.com/opennota/check",
+        "description": "Find unused global variables and constants.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "vera++": {
+        "categories": [
+            "formatter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [],
+        "licenses": [
+            "BSL-1.0 (original text)"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://bitbucket.org/verateam/vera/wiki/Introduction",
+        "source": "https://bitbucket.org/verateam/vera/src/master",
+        "description": "Vera++ is a programmable tool for verification, analysis and transformation of C++ source code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "verible-linter-action": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "verilog"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache-2.0 License"
+        ],
+        "types": [
+            "service"
+        ],
+        "homepage": "https://github.com/chipsalliance/verible-linter-action",
+        "source": "https://github.com/chipsalliance/verible-linter-action",
+        "description": "Automatic SystemVerilog linting in github actions with the help of Verible Used to lint Verilog and SystemVerilog source files and comment erroneous lines  of code in Pull Requests automatically.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "vint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "vim-script"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://github.com/Kuniwak/vint",
+        "source": "https://github.com/Kuniwak/vint",
+        "description": "Fast and Highly Extensible Vim script Language Lint implemented by Python.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "vscode-verilog-hdl-support": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "verilog"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "ide-plugin"
+        ],
+        "homepage": "https://github.com/mshr-h/vscode-verilog-hdl-support",
+        "source": "https://github.com/mshr-h/vscode-verilog-hdl-support",
+        "description": "Verilog HDL/SystemVerilog/Bluespec SystemVerilog support for VS Code. Provides syntax highlighting and Linting support from Icarus Verilog, Vivado Logical Simulation, Modelsim and Verilator",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "vulture": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/jendrikseipp/vulture",
+        "source": "https://github.com/jendrikseipp/vulture",
+        "description": "Find unused classes, functions and variables in Python code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "warnalyzer": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "rust"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT / Apache 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/est31/warnalyzer",
+        "source": "https://github.com/est31/warnalyzer",
+        "description": "Show unused code from multi-crate Rust projects",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "weggli": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "c",
+            "cpp"
+        ],
+        "other": [
+            "security"
+        ],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/googleprojectzero/weggli",
+        "source": "https://github.com/googleprojectzero/weggli",
+        "description": "A fast and robust semantic search tool for C and C++ codebases. It is designed to help security researchers identify interesting functionality in large codebases.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "wemake-python-styleguide": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://wemake-python-stylegui.de",
+        "source": "https://github.com/wemake-services/wemake-python-styleguide",
+        "description": "The strictest and most opinionated python linter ever.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "wily": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "Apache License 2.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/tonybaloney/wily",
+        "source": "https://github.com/tonybaloney/wily",
+        "description": "A command-line tool for archiving, exploring and graphing the complexity of Python source code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "write-good": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "writing"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/btford/write-good",
+        "source": "https://github.com/btford/write-good",
+        "description": "A linter with a focus on eliminating \"weasel words\".",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "wsl": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "go"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/bombsimon/wsl",
+        "source": "https://github.com/bombsimon/wsl",
+        "description": "Enforces empty lines at the right places.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "xenon": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "python"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://xenon.readthedocs.io",
+        "source": "https://github.com/rubik/xenon",
+        "description": "Monitor code complexity using [`radon`](https://github.com/rubik/radon).",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "xo": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/xojs/xo",
+        "source": "https://github.com/xojs/xo",
+        "description": "Opinionated but configurable ESLint wrapper with lots of goodies included. Enforces strict and readable code.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "yamllint": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "template",
+            "yaml"
+        ],
+        "licenses": [
+            "GNU General Public License v3.0"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://yamllint.readthedocs.io",
+        "source": "https://github.com/adrienverge/yamllint",
+        "description": "Checks YAML files for syntax validity, key repetition and cosmetic problems such as lines length, trailing spaces, and indentation.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "yardstick": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "javascript"
+        ],
+        "other": [],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/calmh/yardstick",
+        "source": "https://github.com/calmh/yardstick",
+        "description": "Javascript code metrics.",
+        "discussion": null,
+        "deprecated": true,
+        "resources": null,
+        "wrapper": null
+    },
+    "zydis": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [],
+        "other": [
+            "binary"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://zydis.re",
+        "source": "https://github.com/zyantific/zydis",
+        "description": "Fast and lightweight x86/x86-64 disassembler library",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    },
+    "🐊Putout": {
+        "categories": [
+            "linter"
+        ],
+        "languages": [
+            "flow",
+            "javascript",
+            "jsx",
+            "typescript"
+        ],
+        "other": [
+            "css",
+            "json",
+            "markdown",
+            "yaml"
+        ],
+        "licenses": [
+            "MIT License"
+        ],
+        "types": [
+            "cli"
+        ],
+        "homepage": "https://github.com/coderaiser/putout",
+        "source": "https://github.com/coderaiser/putout",
+        "description": "Pluggable and configurable code transformer with built-in eslint, babel plugins support for js, jsx typescript, flow, markdown, yaml and json.",
+        "discussion": null,
+        "deprecated": null,
+        "resources": null,
+        "wrapper": null
+    }
+}

--- a/data/render/Cargo.lock
+++ b/data/render/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
+checksum = "7a99269dff3bc004caa411f38845c20303f1e393ca2bd6581576fa3a7f59577d"
 
 [[package]]
 name = "askama"
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -76,27 +76,27 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "bytes"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "data-encoding"
@@ -141,11 +141,20 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.28"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -181,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.15"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -195,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -205,35 +214,34 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-io"
-version = "0.3.15"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.15"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
- "autocfg",
  "futures-core",
  "futures-sink",
  "futures-task",
@@ -242,21 +250,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "h2"
-version = "0.3.3"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes",
  "fnv",
@@ -273,24 +270,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
@@ -299,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes",
  "http",
@@ -310,15 +307,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hubcaps"
@@ -349,9 +346,9 @@ checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
 name = "hyper"
-version = "0.14.5"
+version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -363,7 +360,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
@@ -386,14 +383,13 @@ dependencies = [
 
 [[package]]
 name = "hyperx"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82566a1ace7f56f604d83b7b2c259c78e243d99c565f23d7b4ae34466442c5a2"
+checksum = "5617e92fc2f2501c3e2bc6ce547cad841adba2bae5b921c7e52510beca6d084c"
 dependencies = [
  "base64 0.13.0",
  "bytes",
  "http",
- "httparse",
  "httpdate",
  "language-tags",
  "mime",
@@ -414,12 +410,21 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -430,15 +435,15 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itoa"
-version = "0.4.7"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -459,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "language-tags"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -471,9 +476,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "linked-hash-map"
@@ -492,15 +497,15 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "mime"
@@ -526,9 +531,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
 dependencies = [
  "libc",
  "log",
@@ -548,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -577,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -616,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -626,15 +631,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.35"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -646,15 +651,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.64"
+version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209efc2fe0e980c8849efacdb567f975a1c80245c4f6980d6f012733bfa851af"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
 dependencies = [
  "autocfg",
  "cc",
@@ -687,30 +692,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
-name = "pin-project"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -720,79 +705,33 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -832,21 +771,23 @@ dependencies = [
  "pico-args",
  "serde",
  "serde_derive",
+ "serde_json",
  "serde_yaml",
  "tokio",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.11.3"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
 dependencies = [
  "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
@@ -860,6 +801,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde",
+ "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
@@ -887,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "schannel"
@@ -903,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.3.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -916,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.3.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -946,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
@@ -957,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
  "itoa",
@@ -992,15 +934,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -1014,9 +956,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1025,13 +967,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -1050,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1065,9 +1007,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
@@ -1075,6 +1017,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
@@ -1102,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1131,9 +1074,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1142,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
 ]
@@ -1166,12 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
@@ -1208,15 +1148,15 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70455df2fdf4e9bf580a92e443f1eb0303c390d682e2ea817312c9e81f8c3399"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
@@ -1236,21 +1176,19 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1263,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1275,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1285,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1298,15 +1236,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/data/render/Cargo.toml
+++ b/data/render/Cargo.toml
@@ -6,13 +6,14 @@ edition = "2018"
 
 [dependencies]
 serde = "1.0.136"
-serde_derive = "1.0.126"
+serde_derive = "1.0.136"
 serde_yaml = "0.8.23"
 askama = "0.11.1"
 # Switch back to crates as soon as a new release with tokio 1.x support is
 # released. See https://github.com/softprops/hubcaps/pull/285
 hubcaps = { git="https://github.com/softprops/hubcaps" }
-tokio = { version = "1.16.1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.17.0", features = ["rt-multi-thread", "macros"] }
 chrono = "0.4.19"
-anyhow = "1.0.53"
+anyhow = "1.0.54"
 pico-args = "0.4.2"
+serde_json = "1.0.79"

--- a/data/render/src/lib.rs
+++ b/data/render/src/lib.rs
@@ -8,12 +8,15 @@ use hubcaps::{Credentials, Github};
 mod lints;
 pub mod types;
 
-use std::collections::BTreeMap;
-use types::{Catalog, Entry, ParsedEntry, Tag, Type};
+use std::{
+    collections::{BTreeMap, HashSet},
+    iter::FromIterator,
+};
+use types::{Catalog, Entry, ParsedEntry, Resource, Tag, Type};
 
 fn valid(entry: &ParsedEntry, tags: &[Tag]) -> Result<()> {
     let lints = [lints::name, lints::min_one_tag];
-    lints.iter().try_for_each(|lint| Ok(lint(entry, tags)?))
+    lints.iter().try_for_each(|lint| lint(entry, tags))
 }
 
 #[tokio::main]
@@ -62,9 +65,7 @@ pub async fn check_deprecated(token: String, entries: &mut Vec<Entry>) -> Result
     Ok(())
 }
 
-pub fn group(tags: &[Tag], entries: &[Entry]) -> Result<Catalog> {
-    let mut linters = BTreeMap::new();
-
+pub fn create_catalog(entries: &[Entry], languages: &[Tag], other_tags: &[Tag]) -> Result<Catalog> {
     // Move tools that support multiple programming languages into their own category
     let (multi, entries): (Vec<Entry>, Vec<Entry>) = entries.iter().cloned().partition(|entry| {
         let language_tags = entry
@@ -75,11 +76,7 @@ pub fn group(tags: &[Tag], entries: &[Entry]) -> Result<Catalog> {
         language_tags > 1 && !entry.is_c_cpp()
     });
 
-    let languages: Vec<&Tag> = tags
-        .iter()
-        .filter(|t| t.tag_type == Type::Language)
-        .collect();
-
+    let mut linters = BTreeMap::new();
     for language in languages {
         let list: Vec<Entry> = entries
             .iter()
@@ -92,7 +89,6 @@ pub fn group(tags: &[Tag], entries: &[Entry]) -> Result<Catalog> {
     }
 
     let mut others = BTreeMap::new();
-    let other_tags: Vec<&Tag> = tags.iter().filter(|t| t.tag_type == Type::Other).collect();
     for other in other_tags {
         let list: Vec<Entry> = entries
             .iter()
@@ -109,4 +105,91 @@ pub fn group(tags: &[Tag], entries: &[Entry]) -> Result<Catalog> {
         others,
         multi,
     })
+}
+
+/// An entry of the machine-readable JSON out from the tool.
+///
+/// We use a different, de-normalized data format instead of the catalog, which
+/// keeps the information for each tool in a struct instead of grouping tools by
+/// tags.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiEntry {
+    categories: HashSet<String>,
+    languages: Vec<String>,
+    other: Vec<String>,
+    licenses: Vec<String>,
+    types: HashSet<String>,
+    homepage: String,
+    source: Option<String>,
+    description: String,
+    discussion: Option<String>,
+    deprecated: Option<bool>,
+    resources: Option<Vec<Resource>>,
+    wrapper: Option<bool>,
+}
+
+/// The final API dataformat is a map where the key is the entry name and the
+/// value is the entry data, which makes searching for a tool's data easier
+type Api = BTreeMap<String, ApiEntry>;
+
+pub fn create_api(catalog: Catalog, languages: &[Tag], other_tags: &[Tag]) -> Result<Api> {
+    let mut api_entries = BTreeMap::new();
+
+    // Concatenate all entries into one vector
+    let mut entries: Vec<Entry> = Vec::from_iter(catalog.linters.into_values().flatten());
+    entries.extend(Vec::from_iter(catalog.others.into_values().flatten()));
+    entries.extend(catalog.multi);
+
+    for entry in entries {
+        // Get the language data for the entry. We iterate over all languages
+        // and look up each language in the entry tags This is an O(n) operation
+        // as we iterate over the language list only once while the lookup is an
+        // O(1) operation thanks to the tag hash set.
+        let entry_languages = languages
+            .iter()
+            .filter_map(|lang| {
+                if entry.tags.contains(lang) {
+                    entry.tags.get(lang).map(|tag| tag.tag.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // ...same for the non-language tags
+        let entry_other = other_tags
+            .iter()
+            .filter_map(|other| {
+                if entry.tags.contains(other) {
+                    entry.tags.get(other).map(|tag| tag.tag.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // In the future we want to split up licenses in the YAML input files into a list.
+        // Emulate the future data format by creating a list from the current string.
+        // Note that this string could contain more than one license name for now, e.g.
+        // MIT / Apache License
+        let licenses = vec![entry.license];
+
+        let api_entry = ApiEntry {
+            categories: entry.categories,
+            languages: entry_languages,
+            other: entry_other,
+            licenses,
+            types: entry.types,
+            homepage: entry.homepage,
+            source: entry.source,
+            description: entry.description,
+            discussion: entry.discussion,
+            deprecated: entry.deprecated,
+            resources: entry.resources,
+            wrapper: entry.wrapper,
+        };
+        api_entries.insert(entry.name, api_entry);
+    }
+
+    Ok(api_entries)
 }


### PR DESCRIPTION
Render a map as a JSON file where the key is the entry name and the
value is the entry data, which makes searching for a tool's data easier
when using tools like jq.

We use a different, de-normalized data format instead of the catalog, which
keeps the information for each tool in a struct instead of grouping tools by
tags.

Note that this data is not meant to be edited directly.

<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->
