### PR TITLE
Remove misleading tags

### DIFF
--- a/data/tools/trustinsoft.yml
+++ b/data/tools/trustinsoft.yml
@@ -4,9 +4,6 @@ categories:
 tags:
   - c
   - cpp
-  - ci
-  - embedded
-  - ocaml
 license: proprietary
 types:
   - cli


### PR DESCRIPTION
Remove TrustInSoft misleading tags that classify the analyzer in the "multiple languages" section rather than "C" and "C++" section

