### PR TITLE
Add Dodgy

### DIFF
--- a/data/tools/dodgy.yml
+++ b/data/tools/dodgy.yml
@@ -1,0 +1,14 @@
+name: Dodgy
+categories:
+  - linter
+tags:
+  - python
+license: MIT License
+types:
+  - cli
+source: "https://github.com/landscapeio/dodgy"
+homepage: "https://github.com/landscapeio/dodgy"
+description: Dodgy is a very basic tool to run against your codebase to search for "dodgy" looking values. It is a series of simple regular expressions designed to detect things such as accidental SCM diff checkins, or passwords or secret keys hard coded into files.
+resources:
+  - title: "Python linters for better code quality"
+    url: https://smirnov-am.github.io/python-linters-for-better-code-quality/


### PR DESCRIPTION
Dodgy is a very basic tool to run against your code base to search for "dodgy" looking values. It is a series of simple regular expressions designed to detect things such as accidental SCM diff checkins, or passwords or secret keys hard coded into files.

<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->

* [x] I have not changed the `README.md` directly.


