### PR TITLE
Add Regal, the Rego linter

### DIFF
--- a/data/tags.yml
+++ b/data/tags.yml
@@ -256,6 +256,9 @@
 - name: Raku
   value: raku
   type: language
+- name: Rego
+  value: rego
+  type: language
 - name: Ruby
   value: ruby
   type: language

--- a/data/tools/regal.yml
+++ b/data/tools/regal.yml
@@ -1,0 +1,19 @@
+name: Regal
+categories:
+  - linter
+tags:
+  - rego
+license: Apache License 2.0
+types:
+  - cli
+source: 'https://github.com/styrainc/regal'
+homepage: 'https://github.com/styrainc/regal'
+description: >-
+  Regal is a linter for the policy language Rego. Regal aims to catch bugs and mistakes
+  in policy code, while at the same time helping people learn the language, best practices
+  and idiomatic constructs.
+resources:
+  - title: 'Guarding the Guardrails — Introducing Regal, the Rego Linter'
+    url: 'https://www.styra.com/blog/guarding-the-guardrails-introducing-regal-the-rego-linter'
+  - title: 'Regal the Rego Linter, CNCF London meetup, June 2023 (video)'
+    url: 'https://www.youtube.com/watch?v=Xx8npd2TQJ0&t=2567s'


### PR DESCRIPTION
New linter for Open Policy Agent's Rego language.

<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->

* [x] I have not changed the `README.md` directly, but it was tempting.


