### PR TITLE
Add Kani to tools

### DIFF
--- a/data/tools/kani.yml
+++ b/data/tools/kani.yml
@@ -1,0 +1,19 @@
+name: kani
+categories:
+  - wasd
+tags:
+  - rust
+  - Security/SAST
+license: 'MIT & Apache 2.0' 
+source: 'https://github.com/model-checking/kani'
+homepage: 'https://github.com/model-checking/kani'
+description: >-
+  The Kani Rust Verifier is a bit-precise model checker for Rust. 
+  Kani is particularly useful for verifying unsafe code blocks in Rust, 
+  where the "unsafe superpowers" are unchecked by the compiler.
+  Kani verifies:
+  
+  * Memory safety (e.g., null pointer dereferences)
+  * User-specified assertions (i.e., assert!(...))
+  * The absence of panics (e.g., unwrap() on None values)
+  * The absence of some types of unexpected behavior (e.g., arithmetic overflows)

--- a/data/tools/kani.yml
+++ b/data/tools/kani.yml
@@ -3,7 +3,7 @@ categories:
   - wasd
 tags:
   - rust
-  - Security/SAST
+  - security
 license: 'MIT & Apache 2.0' 
 source: 'https://github.com/model-checking/kani'
 homepage: 'https://github.com/model-checking/kani'

--- a/data/tools/kani.yml
+++ b/data/tools/kani.yml
@@ -1,6 +1,6 @@
 name: kani
 categories:
-  - wasd
+  - linter
 tags:
   - rust
   - security

--- a/data/tools/kani.yml
+++ b/data/tools/kani.yml
@@ -1,6 +1,8 @@
 name: kani
 categories:
   - linter
+types:
+  - cli
 tags:
   - rust
   - security


### PR DESCRIPTION
I came across your rather useful list, noticed that a tool I've been playing with is missing.

The tool is called [Kani, it's a model-checker for Rust.](https://github.com/model-checking/kani).
It has 1.5k stars, 38 contributiors, and is at least 2 years old, so I believe it meets all the criteria. 

* [x] I have not changed the `README.md` directly.


