### PR TITLE
Update luacheck.yml

### DIFF
--- a/data/tools/luacheck.yml
+++ b/data/tools/luacheck.yml
@@ -6,6 +6,6 @@ tags:
 license: MIT License
 types:
   - cli
-source: 'https://github.com/mpeterv/luacheck'
-homepage: 'https://github.com/mpeterv/luacheck'
+source: 'https://github.com/lunarmodules/luacheck'
+homepage: 'https://github.com/lunarmodules/luacheck'
 description: A tool for linting and static analysis of Lua code.


### PR DESCRIPTION
The owner of original luacheck repository passed away some years ago, see [1].
New development is done at https://github.com/lunarmodules/luacheck

[1] https://github.com/mpeterv/luacheck/issues/198