### PR TITLE
Fix spelling of Error Prone tool

### DIFF
--- a/data/api/tools.json
+++ b/data/api/tools.json
@@ -6059,7 +6059,7 @@
     "wrapper": null
   },
   "error-prone": {
-    "name": "Error-prone",
+    "name": "Error Prone",
     "categories": [
       "linter"
     ],

--- a/data/tools/error-prone.yml
+++ b/data/tools/error-prone.yml
@@ -1,4 +1,4 @@
-name: Error-prone
+name: Error Prone
 categories:
   - linter
 tags:


### PR DESCRIPTION
* [x] I have not changed the `README.md` directly.


