### PR TITLE
Narrow the tags for fta

### DIFF
--- a/data/tools/fta.yml
+++ b/data/tools/fta.yml
@@ -5,9 +5,6 @@ types:
   - cli
 tags:
   - typescript
-  - javascript
-  - wasm
-  - rust
 license: MIT
 source: 'https://github.com/sgb-io/fta'
 homepage: 'https://ftaproject.dev/'


### PR DESCRIPTION
FTA is primarily targeting TypeScript so I'm reducing it's tags to have it under the TypeScript heading only

* [x] I have not changed the `README.md` directly.


