### PR TITLE
Mark dagda as unmaintained

### DIFF
--- a/data/tools/dagda.yml
+++ b/data/tools/dagda.yml
@@ -9,3 +9,4 @@ types:
 source: 'https://github.com/eliasgranderubio/dagda'
 homepage: 'https://github.com/eliasgranderubio/dagda'
 description: Perform static analysis of known vulnerabilities in docker images/containers.
+deprecated: true


### PR DESCRIPTION
* [x] I have not changed the `README.md` directly.

I'd suggest to mark [dagda](https://github.com/eliasgranderubio/dagda) as unmaintained for the following reasons:

- No new commit since over two years
- 5 new issues (some of them critical bugs) unanswered for the last two years
- 4 open PRs from other users without response from maintainer
- 5 open dependabot PRs
