### PR TITLE
Update larastan.yml to use Larastan Org

### DIFF
--- a/data/tools/larastan.yml
+++ b/data/tools/larastan.yml
@@ -7,8 +7,8 @@ tags:
 license: MIT License
 types:
   - cli
-source: 'https://github.com/nunomaduro/larastan'
-homepage: 'https://github.com/nunomaduro/larastan'
+source: 'https://github.com/larastan/larastan'
+homepage: 'https://github.com/larastan/larastan'
 description:  >-
   Adds static analysis to Laravel improving developer productivity and code quality.
   It is a wrapper around PHPStan.


### PR DESCRIPTION
Starting with Larastan 2.7.0, the Larastan repository will now be managed under the Larastan organization.

<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->

* [x] I have not changed the `README.md` directly.


