### PR TITLE
Mark flint++ as deprecated

### DIFF
--- a/data/tools/flint.yml
+++ b/data/tools/flint.yml
@@ -4,6 +4,7 @@ categories:
 tags:
   - c
   - cpp
+deprecated: true
 license: Boost Software License 1.0
 types:
   - cli


### PR DESCRIPTION
The [flint++ repository](https://github.com/JossWhittle/FlintPlusPlus) is archived as of August 2023, so mark the tool as deprecated.

* [x] I have not changed the `README.md` directly.


