### PR TITLE
Add Precaution CLI as a SAST

### DIFF
--- a/data/tools/precaution.yml
+++ b/data/tools/precaution.yml
@@ -10,10 +10,18 @@ tags:
 license: Business Source License 1.1
 types:
   - cli
+  - service
 source: 'https://github.com/securesauce/precli'
-homepage: 'https://precli.readthedocs.io/latest/'
+homepage: 'https://www.securesauce.dev/'
 resources:
   - title: Introducing Precaution
     url: https://blog.securesauce.dev/introducing-precaution
+plans:
+  oss: true
+  free: true
+pricing: https://www.securesauce.dev/
 description: >-
-   Precaution CLI - command line static application security testing tool
+   Precaution is a static analysis security tool (SAST) designed
+   to find potentially critical vulnerabilities in source code prior
+   to production. It is available as a CLI, GitHub Action, and GitHub
+   App.

--- a/data/tools/precaution.yml
+++ b/data/tools/precaution.yml
@@ -1,0 +1,19 @@
+name: Precaution
+categories:
+  - linter
+tags:
+  - ci
+  - go
+  - java
+  - python
+  - security
+license: Business Source License 1.1
+types:
+  - cli
+source: 'https://github.com/securesauce/precli'
+homepage: 'https://precli.readthedocs.io/latest/'
+resources:
+  - title: Introducing Precaution
+    url: https://blog.securesauce.dev/introducing-precaution
+description: >-
+   Precaution CLI - command line static application security testing tool


### PR DESCRIPTION
Precli (or PrecautionCLI) is another SAST that checks Go, Java, and Python code for security vulnerabilities. A free-to-use CLI is available that covers standard library of each language. Also available is a GitHub Action and GitHub App.

<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->

* [x] I have not changed the `README.md` directly.


