### PR TITLE
Add podcast about Bandit to its tool metadata

### DIFF
--- a/data/tools/bandit.yml
+++ b/data/tools/bandit.yml
@@ -12,3 +12,5 @@ description: A tool to find common security issues in Python code.
 resources:
   - title: "Code security with Bandit and Safety — Perfect Python"
     url: https://www.youtube.com/watch?v=YZOKnvisJpw
+  - title: "The Python Podcast.__init__: Bandit with Tim Kelsey, Travis McPeak, and Eric Brown - E62"
+    url: https://www.pythonpodcast.com/episodepage/bandit-with-tim-kelsey-travis-mcpeak-and-eric-brown


### PR DESCRIPTION
Back in 2016, there was a nice podcast interview with the maintainers of Bandit that would be nice to include here.

https://www.pythonpodcast.com/episodepage/bandit-with-tim-kelsey-travis-mcpeak-and-eric-brown

<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->

* [x] I have not changed the `README.md` directly.


