### PR TITLE
Add four new static analysis tool from XJTU-ENRE group in GitHub

### DIFF
--- a/data/tools/enre-cpp.yml
+++ b/data/tools/enre-cpp.yml
@@ -1,0 +1,15 @@
+name: ENRE-cpp
+categories:
+  - linter
+tags:
+  - c
+  - cpp
+license: LGPL-2.1 license
+types:
+  - cli
+source: 'https://github.com/xjtu-enre/ENRE-cpp'
+homepage: 'https://github.com/xjtu-enre/ENRE-cpp'
+description: >-
+  ENRE (ENtity Relationship Extractor) is a tool for extraction of code entity dependencies or relationships from source code.
+  ENRE-cpp is a ENtity Relationship Extractor for C++ based on Eclipse/CDT.
+

--- a/data/tools/enre-cpp.yml
+++ b/data/tools/enre-cpp.yml
@@ -11,5 +11,5 @@ source: 'https://github.com/xjtu-enre/ENRE-cpp'
 homepage: 'https://github.com/xjtu-enre/ENRE-cpp'
 description: >-
   ENRE (ENtity Relationship Extractor) is a tool for extraction of code entity dependencies or relationships from source code.
-  ENRE-cpp is a ENtity Relationship Extractor for C++ based on Eclipse/CDT.
+  ENRE-cpp is a ENtity Relationship Extractor for C/C++ based on @eclipse/CDT. (Under development)
 

--- a/data/tools/enre-java.yml
+++ b/data/tools/enre-java.yml
@@ -1,0 +1,14 @@
+name: ENRE-java
+categories:
+  - linter
+tags:
+  - java
+license: LGPL-2.1 license
+types:
+  - cli
+source: 'https://github.com/xjtu-enre/ENRE-java'
+homepage: 'https://github.com/xjtu-enre/ENRE-java'
+description: >-
+  ENRE (ENtity Relationship Extractor) is a tool for extraction of code entity dependencies or relationships from source code.
+  ENRE-java is a ENtity Relationship Extractor for Java projects based on @Eclipse JDT/parser.
+

--- a/data/tools/enre-py.yml
+++ b/data/tools/enre-py.yml
@@ -1,0 +1,14 @@
+name: ENRE-py
+categories:
+  - linter
+tags:
+  - python
+license: LGPL-2.1 license
+types:
+  - cli
+source: 'https://github.com/xjtu-enre/ENRE-py'
+homepage: 'https://github.com/xjtu-enre/ENRE-py'
+description: >-
+  ENRE (ENtity Relationship Extractor) is a tool for extraction of code entity dependencies or relationships from source code.
+  ENRE-py is a ENtity Relationship Extractor for Python based on Python Language Services of The Standard Library.
+

--- a/data/tools/enre-ts.yml
+++ b/data/tools/enre-ts.yml
@@ -1,0 +1,14 @@
+name: ENRE-ts
+categories:
+  - linter
+tags:
+  - typescript
+license: LGPL-2.1 license
+types:
+  - cli
+source: 'https://github.com/xjtu-enre/ENRE-ts'
+homepage: 'https://github.com/xjtu-enre/ENRE-ts'
+description: >-
+  ENRE (ENtity Relationship Extractor) is a tool for extraction of code entity dependencies or relationships from source code.
+  ENRE-ts is a ENtity Relationship Extractor for ECMAScript and TypeScript based on @babel/parser.
+


### PR DESCRIPTION
Add four new static analysis tool from [XJTU-ENRE](https://github.com/xjtu-enre) group in GitHub, which are **ENRE-cpp, ENRE-java, ENRE-py, ENRE-ts**.  The related .yml files have been added be added to `data/tools/`, and the `make` command was run to modify the readme file.
* [x] I have not changed the `README.md` directly.


