### PR TITLE
Doop Framework moved their source code to github

### DIFF
--- a/data/tools/doop.yml
+++ b/data/tools/doop.yml
@@ -6,6 +6,6 @@ tags:
 license: UPL
 types:
   - cli
-source: 'https://bitbucket.org/yanniss/doop'
-homepage: 'https://bitbucket.org/yanniss/doop'
+source: 'https://github.com/plast-lab/doop'
+homepage: 'https://plast-lab.github.io/doop-pldi15-tutorial/'
 description: Doop is a declarative framework for static analysis of Java/Android programs, centered on pointer analysis algorithms. Doop provides a large variety of analyses and also the surrounding scaffolding to run an analysis end-to-end (fact generation, processing, statistics, etc.).


### PR DESCRIPTION
<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->

* [x] I have not changed the `README.md` directly.
The Doop Framework archived their bitbucket repository and moved their code to github, so the links do not work.
