### PR TITLE
Add code depends (static analysis for R)

### DIFF
--- a/data/tools/codedepends.yml
+++ b/data/tools/codedepends.yml
@@ -1,0 +1,12 @@
+name: CodeDepends
+categories:
+  - linter
+tags:
+  - r
+license: GPL
+types:
+  - cli
+deprecated: true
+source: 'https://github.com/duncantl/CodeDepends'
+homepage: 'https://github.com/duncantl/CodeDepends'
+description: Static Code Analysis for R.


### PR DESCRIPTION
<!--

👋 Thank you for your contribution!
Please make sure to check all of the items below.

- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
- If you propose to deprecate a tool, you have to provide a reason below.
- More details in the contributors guide, `CONTRIBUTING.md`

-->

* [x] I have not changed the `README.md` directly.

Even though code depends has not changed in two years (hence the deprecation marker) it is still an important analyzer for the R programming language (more important would be the successor <https://github.com/duncantl/CodeAnalysis> but it does not clear the stars-constraint, which in general is hard to hit as static analysis for R remains heavily underrepresented wrt. other languages). 
