### PR TITLE
Fix broken URLs in tool definitions

### DIFF
--- a/data/tools/betterscan.yml
+++ b/data/tools/betterscan.yml
@@ -21,9 +21,10 @@ tags:
   - typescript
   - python
   - security
-license: AGPL-3.0 
+license: AGPL-3.0
 types:
   - cli
+deprecated: true
 source: "https://github.com/tcosolutions/betterscan-ce"
 homepage: "https://github.com/tcosolutions/betterscan-ce"
 plans:

--- a/data/tools/bugprove.yml
+++ b/data/tools/bugprove.yml
@@ -6,12 +6,13 @@ tags:
   - binary
   - c
   - cpp
-  - security  
+  - security
 license: proprietary
 types:
   - cli
 plans:
   free: true
+deprecated: true
 homepage: "https://www.bugprove.com"
 description: >-
   BugProve is a firmware analysis platform featuring both static and dynamic analysis

--- a/data/tools/cpplint.yml
+++ b/data/tools/cpplint.yml
@@ -7,6 +7,6 @@ tags:
 license: Apache-2.0
 types:
   - cli
-source: 'https://github.com/google/styleguide/tree/gh-pages/cpplint'
-homepage: 'https://github.com/google/styleguide/tree/gh-pages/cpplint'
+source: "https://github.com/cpplint/cpplint"
+homepage: "https://github.com/cpplint/cpplint"
 description: Automated C++ checker that follows Google's style guide.

--- a/data/tools/fsharplint.yml
+++ b/data/tools/fsharplint.yml
@@ -6,6 +6,6 @@ tags:
 license: MIT License
 types:
   - cli
-source: 'https://github.com/fsprojects/FSharpLint'
-homepage: 'https://fsprojects.github.io/FSharpLint'
+source: "https://github.com/fsprojects/FSharpLint"
+homepage: "https://github.com/fsprojects/FSharpLint"
 description: Lint tool for F#.

--- a/data/tools/hasmysecretleaked.yml
+++ b/data/tools/hasmysecretleaked.yml
@@ -8,8 +8,9 @@ license: proprietary
 types:
   - cli
   - service
-homepage: 'https://gitguardian.com/hasmysecretleaked'
-source: 'https://github.com/GitGuardian/ggshield'
+deprecated: true
+homepage: "https://gitguardian.com/hasmysecretleaked"
+source: "https://github.com/GitGuardian/ggshield"
 description: >-
   HasMySecretLeaked is a project from GitGuardian that aims to help individual users
   and organizations search across 20 million exposed secrets to verify if their 

--- a/data/tools/kubeval.yml
+++ b/data/tools/kubeval.yml
@@ -6,6 +6,7 @@ tags:
 license: Other
 types:
   - cli
+deprecated: true
 source: "https://github.com/instrumenta/kubeval"
 homepage: "https://kubeval.instrumenta.dev"
 description: >-

--- a/data/tools/linter-for-dart.yml
+++ b/data/tools/linter-for-dart.yml
@@ -6,6 +6,6 @@ tags:
 license: BSD 3-Clause "New" or "Revised" License
 types:
   - cli
-source: 'https://github.com/dart-lang/linter'
-homepage: 'https://dart-lang.github.io/linter'
+source: "https://github.com/dart-lang/linter"
+homepage: "https://github.com/dart-lang/linter"
 description: Style linter for Dart.

--- a/data/tools/scrutinizer.yml
+++ b/data/tools/scrutinizer.yml
@@ -13,6 +13,7 @@ tags:
 license: proprietary
 types:
   - service
+deprecated: true
 homepage: https://scrutinizer-ci.com
 description: >-
   A proprietary code quality checker that can be integrated with GitHub.

--- a/data/tools/specificity-graph.yml
+++ b/data/tools/specificity-graph.yml
@@ -6,6 +6,6 @@ tags:
 license: MIT License
 types:
   - cli
-source: 'https://github.com/pocketjoso/specificity-graph'
-homepage: 'https://jonassebastianohlsson.com/specificity-graph'
+source: "https://github.com/pocketjoso/specificity-graph"
+homepage: "https://github.com/pocketjoso/specificity-graph"
 description: CSS Specificity Graph Generator.

--- a/data/tools/statix.yml
+++ b/data/tools/statix.yml
@@ -5,9 +5,9 @@ tags:
   - nix
 license: MIT
 types:
-  - cli 
-source: 'https://github.com/nerdypepper/statix'
-homepage: 'https://git.peppe.rs/languages/statix/about/'
+  - cli
+source: "https://github.com/nerdypepper/statix"
+homepage: "https://github.com/nerdypepper/statix"
 description: >-
   Lints and suggestions for the Nix programming language.
   "statix check" highlights antipatterns in Nix code. "statix fix" can fix several such occurrences.

--- a/data/tools/steady.yml
+++ b/data/tools/steady.yml
@@ -6,6 +6,7 @@ tags:
 license: Apache-2.0
 types:
   - cli
+deprecated: true
 source: "https://github.com/eclipse/steady"
 homepage: "https://eclipse.github.io/steady/"
 description: >-

--- a/data/tools/twiggy.yml
+++ b/data/tools/twiggy.yml
@@ -8,7 +8,7 @@ license: Other
 types:
   - cli
 source: "https://github.com/rustwasm/twiggy"
-homepage: "https://rustwasm.github.io/twiggy"
+homepage: "https://github.com/rustwasm/twiggy"
 description: >-
   Analyzes a binary's call graph to profile code size. The goal is to slim down
   wasm binary size.


### PR DESCRIPTION
This PR fixes the broken URLs reported in the link checker by either updating them to working alternatives or marking the tools as deprecated.

## Changes Made

### Updated URLs (6 tools)
- **linter-for-dart.yml**: Changed homepage from broken GitHub Pages to GitHub repository
- **fsharplint.yml**: Changed homepage from broken GitHub Pages to GitHub repository  
- **statix.yml**: Changed homepage from unreachable git.peppe.rs to GitHub repository
- **cpplint.yml**: Updated source and homepage to the current cpplint repository
- **specificity-graph.yml**: Changed homepage from broken personal website to GitHub repository
- **twiggy.yml**: Changed homepage from broken GitHub Pages to GitHub repository

### Marked as Deprecated (6 tools)
- **bugprove.yml**: Domain unreachable (certificate/network errors)
- **steady.yml**: GitHub Pages site not found (404)
- **hasmysecretleaked.yml**: Gateway timeout (504)
- **betterscan.yml**: Website unreachable and GitHub repository archived
- **kubeval.yml**: Domain unreachable (certificate errors)  
- **scrutinizer.yml**: Service unavailable (503)

## Link Checker Errors Fixed

This addresses all the broken links mentioned in the GitHub Actions error:
- [ERROR] https://bugprove.com/ ✅ Deprecated
- [404] https://dart-lang.github.io/linter ✅ Updated to GitHub repo
- [404] https://eclipse.github.io/steady/ ✅ Deprecated  
- [404] https://fsprojects.github.io/FSharpLint ✅ Updated to GitHub repo
- [TIMEOUT] https://git.peppe.rs/languages/statix/about/ ✅ Updated to GitHub repo
- [504] https://gitguardian.com/hasmysecretleaked ✅ Deprecated
- [404] https://github.com/google/styleguide/tree/gh-pages/cpplint ✅ Updated to current repo
- [404] https://github.com/tcosolutions/betterscan-ce ✅ Deprecated
- [404] https://jonassebastianohlsson.com/specificity-graph ✅ Updated to GitHub repo
- [ERROR] https://kubeval.instrumenta.dev/ ✅ Deprecated
- [404] https://rustwasm.github.io/twiggy ✅ Updated to GitHub repo
- [503] https://scrutinizer-ci.com/ ✅ Deprecated
- [ERROR] https://www.betterscan.io/ ✅ Deprecated

All changes preserve the original functionality while providing working URLs or properly marking tools as deprecated using the `deprecated: true` flag as shown in the existing codebase.