### PR TITLE
Add MISS_HIT for MATLAB analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 
 - [Gendarme](https://www.mono-project.com/docs/tools+libraries/tools/gendarme) — Gendarme inspects programs and libraries that contain code in ECMA CIL format (Mono and .NET).
 
-- **Infer#** :warning: — InferSharp (also referred to as Infer#) is an interprocedural and  scalable static code analyzer for C#. Via the capabilities of Facebook's Infer,  this tool detects null pointer dereferences and resource leaks.
+- [Infer#](https://github.com/microsoft/infersharp) — InferSharp (also referred to as Infer#) is an interprocedural and  scalable static code analyzer for C#. Via the capabilities of Facebook's Infer,  this tool detects null pointer dereferences and resource leaks.
 
 - [Meziantou.Analyzer](https://github.com/meziantou/Meziantou.Analyzer) — A Roslyn analyzer to enforce some good practices in C# in terms of design, usage, security, performance, and style.
 
@@ -772,6 +772,8 @@ A ktfmt IntelliJ plugin is available from the plugin repository. To install it, 
 <a name="matlab" />
 <h2>MATLAB</h2>
 
+
+- [MISS_HIT](https://misshit.org/) — MISS_HIT is a free, open-source code quality toolset for MATLAB, Simulink, and Octave. It includes MH Style (style checker and formatter), MH Metrics (complexity metrics), MH Lint (static analysis), MH Trace (requirements traceability), and MH Copyright (copyright management). Designed to work standalone without requiring MATLAB/Octave installation.
 
 - [mlint](https://www.mathworks.com/help/matlab/ref/mlint.html) :copyright: — Check MATLAB code files for possible problems.
 
@@ -1705,7 +1707,7 @@ Loading address: binbloom can parse a raw binary firmware and determine its load
 
 - [Ghidra](https://ghidra-sre.org) — A software reverse engineering (SRE) suite of tools developed by NSA's Research Directorate in support of the Cybersecurity mission
 
-- [Hopper](https://www.hopperapp.com/) :copyright: — macOS and Linux reverse engineering tool that lets you disassemble, decompile and debug applications. Hopper displays the code using different representations, e.g. the Control Flow Graph, and the pseudo-code of a procedure. Supports Apple Silicon.
+- **Hopper** :warning: :copyright: — macOS and Linux reverse engineering tool that lets you disassemble, decompile and debug applications. Hopper displays the code using different representations, e.g. the Control Flow Graph, and the pseudo-code of a procedure. Supports Apple Silicon.
 
 - [IDA Free](https://www.hex-rays.com/products/ida/support/download_freeware) :copyright: — Binary code analysis tool.
 
@@ -2201,7 +2203,7 @@ It does this by running periodic diff outputs against heuristically crafted rege
 
 - [gokart](https://github.com/praetorian-inc/gokart) — Golang security analysis with a focus on minimizing false positives. It is capable of tracing the source of variables and function arguments  to determine whether input sources are safe.
 
-- [HasMySecretLeaked](https://gitguardian.com/hasmysecretleaked) :copyright: — HasMySecretLeaked is a project from GitGuardian that aims to help individual users and organizations search across 20 million exposed secrets to verify if their  developer secrets have leaked on public repositories, gists, and issues on GitHub projects.
+- **HasMySecretLeaked** :warning: :copyright: — HasMySecretLeaked is a project from GitGuardian that aims to help individual users and organizations search across 20 million exposed secrets to verify if their  developer secrets have leaked on public repositories, gists, and issues on GitHub projects.
 
 - **iblessing** :warning: — iblessing is an iOS security exploiting toolkit. It can be used for reverse engineering, binary analysis and vulnerability mining.
 
@@ -2364,7 +2366,7 @@ TruffleHog is an open source secret-scanning engine that resolves exposed secret
 
 - [GitGuardian ggshield](https://www.gitguardian.com/ggshield) — ggshield is a CLI application that runs in your local environment  or in a CI environment to help you detect more than 350+ types of secrets,  as well as other potential security vulnerabilities or policy breaks affecting your codebase.
 
-- [HasMySecretLeaked](https://gitguardian.com/hasmysecretleaked) :copyright: — HasMySecretLeaked is a project from GitGuardian that aims to help individual users and organizations search across 20 million exposed secrets to verify if their  developer secrets have leaked on public repositories, gists, and issues on GitHub projects.
+- **HasMySecretLeaked** :warning: :copyright: — HasMySecretLeaked is a project from GitGuardian that aims to help individual users and organizations search across 20 million exposed secrets to verify if their  developer secrets have leaked on public repositories, gists, and issues on GitHub projects.
 
 
 ## More Collections

--- a/data/api/tools.json
+++ b/data/api/tools.json
@@ -9084,7 +9084,7 @@
     "plans": null,
     "description": "HasMySecretLeaked is a project from GitGuardian that aims to help individual users and organizations search across 20 million exposed secrets to verify if their  developer secrets have leaked on public repositories, gists, and issues on GitHub projects.",
     "discussion": null,
-    "deprecated": null,
+    "deprecated": true,
     "resources": null,
     "reviews": null,
     "demos": null,
@@ -11783,7 +11783,7 @@
     "plans": null,
     "description": "Format markdown code blocks using your favorite code formatters.",
     "discussion": null,
-    "deprecated": null,
+    "deprecated": false,
     "resources": null,
     "reviews": null,
     "demos": null,
@@ -11979,6 +11979,34 @@
     "description": "And abstract interpreter operating on Rust's mid-level intermediate language, and providing warnings based on taint analysis.",
     "discussion": null,
     "deprecated": true,
+    "resources": null,
+    "reviews": null,
+    "demos": null,
+    "wrapper": null
+  },
+  "miss-hit": {
+    "name": "MISS_HIT",
+    "categories": [
+      "linter",
+      "formatter"
+    ],
+    "languages": [
+      "matlab"
+    ],
+    "other": [],
+    "licenses": [
+      "GPL-3.0"
+    ],
+    "types": [
+      "cli"
+    ],
+    "homepage": "https://misshit.org/",
+    "source": "https://github.com/florianschanda/miss_hit",
+    "pricing": null,
+    "plans": null,
+    "description": "MISS_HIT is a free, open-source code quality toolset for MATLAB, Simulink, and Octave. It includes MH Style (style checker and formatter), MH Metrics (complexity metrics), MH Lint (static analysis), MH Trace (requirements traceability), and MH Copyright (copyright management). Designed to work standalone without requiring MATLAB/Octave installation.",
+    "discussion": null,
+    "deprecated": null,
     "resources": null,
     "reviews": null,
     "demos": null,

--- a/data/tools/misshit.yml
+++ b/data/tools/misshit.yml
@@ -1,0 +1,17 @@
+name: MISS_HIT
+categories:
+  - linter
+  - formatter
+tags:
+  - matlab
+license: GPL-3.0
+types:
+  - cli
+source: "https://github.com/florianschanda/miss_hit"
+homepage: "https://misshit.org/"
+description: >-
+  MISS_HIT is a free, open-source code quality toolset for MATLAB, Simulink,
+  and Octave. It includes MH Style (style checker and formatter), MH Metrics
+  (complexity metrics), MH Lint (static analysis), MH Trace (requirements
+  traceability), and MH Copyright (copyright management). Designed to work
+  standalone without requiring MATLAB/Octave installation.


### PR DESCRIPTION
Add MISS_HIT, a comprehensive code quality toolset for MATLAB, Simulink, and Octave that includes style checking, formatting, metrics, static analysis, requirements traceability, and copyright management.