### PR TITLE
Add Malcat for binary analysis

### DIFF
--- a/data/tools/malcat.yml
+++ b/data/tools/malcat.yml
@@ -1,0 +1,19 @@
+name: Malcat
+categories:
+  - linter
+tags:
+  - binary
+  - security
+license: proprietary
+types:
+  - gui
+plans:
+  free: true
+homepage: "https://malcat.fr/"
+description: >-
+  Hexadecimal editor and disassembler for malware analysis and binary file
+  inspection. Supports over 50 file formats and multiple CPU architectures
+  (x86/x64, MIPS, .NET, Python, VB p-code). Features rapid analysis,
+  embedded file extraction, Yara signature scanning, anomaly detection,
+  and Python scripting. Designed for malware analysts, SOC operators,
+  incident responders, and CTF players.


### PR DESCRIPTION
Add Malcat, a hexadecimal editor and disassembler for malware analysis. Supports 50+ file formats, multiple CPU architectures, and includes features like Yara scanning, anomaly detection, and Python scripting.