### PR TITLE
Add mago tool configuration to data/tools

### DIFF
--- a/data/tools/mago.yml
+++ b/data/tools/mago.yml
@@ -1,0 +1,19 @@
+name: mago
+categories:
+  - linter
+  - formatter
+tags:
+  - php  
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/carthage-software/mago'
+homepage: 'https://mago.carthage.software'
+description:  >-
+    Mago is a complete toolchain for PHP, written in Rust, designed from the ground up for maximum performance.
+    
+    - ✨ A blazing-fast formatter that automatically formats your code according to PER-CS, ending style debates forever.
+    - 🔎 An intelligent linter that catches stylistic issues, inconsistencies, and code smells before they become problems.
+    - 🔬 A powerful static analyzer that finds type errors and logical bugs in your code without you ever having to run it.
+    - 🛡️ A robust architectural guard that enforces dependency rules and structural conventions.
+  


### PR DESCRIPTION
Mago is a complete toolchain for PHP, written in Rust, designed for maximum performance, including a formatter, linter, static analyzer, and architectural guard.

* [x] I have not changed the `README.md` directly.


