### PR TITLE
Frama looks like C-only, no C++.  But gcc does both.

### DIFF
--- a/data/tools/frama-c.yml
+++ b/data/tools/frama-c.yml
@@ -3,7 +3,6 @@ categories:
   - linter
 tags:
   - c
-  - cpp
 license: GNU Lesser General Public License v2.1
 types:
   - cli

--- a/data/tools/gcc.yml
+++ b/data/tools/gcc.yml
@@ -3,6 +3,7 @@ categories:
   - linter
 tags:
   - c
+  - cpp
 license: GPL
 types:
   - cli


### PR DESCRIPTION
I had a look at the Frama site but didn't see any mention of C++.

On the other hand, the gcc analyzers _are_ available for C++.
* [x ] I have not changed the `README.md` directly.


