### PR TITLE
Update links and languages for tangleguard

### DIFF
--- a/data/api/tools.json
+++ b/data/api/tools.json
@@ -20240,7 +20240,7 @@
       "free": false,
       "oss": true
     },
-    "description": "A tool that helps developers to understand and maintain their software architecture. It generates interactive, configurable dependency graphs out of source code, with all packages and modules included. You can choose the level of details and get what portions of your codebase gets rendered. That way you get a quick understanding of the software's architecture and detect unwanted dependencies and spaghetti code which harm efficient maintenance and leads to technical debt and  inflexibility.",
+    "description": "A tool that helps developers to understand and maintain their software architecture. It generates interactive, configurable dependency graphs out of source code, with all packages and modules included. You can choose the level of details and get what portions of your codebase gets rendered. That way you get a quick understanding of the software's architecture and detect unwanted dependencies and spaghetti code which harm efficient maintenance and leads to technical debt and inflexibility.",
     "discussion": null,
     "deprecated": null,
     "resources": [


### PR DESCRIPTION
This PR introduces more reliable and up-to-date links regarding TangleGuard. Also the supported languages got updated.

* [ x ] I have not changed the `README.md` directly.

Not sure though, why the internal link on static-analysis.com produces a 404: https://analysis-tools.dev/tool/tangleguard  

Any idea? 🤔 

