### PR TITLE
Add AppSec Santa SAST comparison to More Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2479,6 +2479,7 @@ TruffleHog is an open source secret-scanning engine that resolves exposed secret
 - [OWASP Source Code Analysis Tools](https://owasp.org/www-community/Source_Code_Analysis_Tools) — List of tools maintained by the Open Web Application Security Project
 - [php-static-analysis-tools](https://github.com/exakat/php-static-analysis-tools) — A reviewed list of useful PHP static analysis tools
 - [Wikipedia](http://en.wikipedia.org/wiki/List_of_tools_for_static_code_analysis) — A list of tools for static code analysis.
+- [AppSec Santa — SAST Tools](https://appsecsanta.com/sast-tools) - Independent comparison of 30+ static analysis security testing tools with features, pricing, and alternatives.
 
 ## License
 


### PR DESCRIPTION
## What is this?

Adding [AppSec Santa — SAST Tools](https://appsecsanta.com/sast-tools) to the **More Collections** section.

This is a dedicated comparison page for 30+ SAST tools covering features, licensing, open-source vs. commercial options, and alternatives. It complements the tool-by-tool entries in this repo by offering a side-by-side overview of the SAST landscape for practitioners evaluating tools.

The site is independently maintained with no vendor sponsorship.