### PR TITLE
Add AppSec Santa to More Collections (template fix)

### DIFF
--- a/data/render/templates/README.md
+++ b/data/render/templates/README.md
@@ -114,6 +114,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 - [linters](https://github.com/mcandre/linters) — An introduction to static code analysis
 - [OWASP Source Code Analysis Tools](https://owasp.org/www-community/Source_Code_Analysis_Tools) — List of tools maintained by the Open Web Application Security Project
 - [php-static-analysis-tools](https://github.com/exakat/php-static-analysis-tools) — A reviewed list of useful PHP static analysis tools
+- [AppSec Santa — SAST Tools](https://appsecsanta.com/sast-tools) — Independent comparison of 30+ static analysis security testing tools with features, pricing, and alternatives
 - [Wikipedia](http://en.wikipedia.org/wiki/List_of_tools_for_static_code_analysis) — A list of tools for static code analysis.
 
 ## License


### PR DESCRIPTION
## Summary

Adds [AppSec Santa — SAST Tools](https://appsecsanta.com/sast-tools) to the **More Collections** section.

This is a follow-up to #1747, which was merged but the change was lost because it edited `README.md` directly instead of the template at `data/render/templates/README.md`.

This PR edits the correct source file so the link persists after the next render.

## What is AppSec Santa?

An independent comparison of 30+ static analysis security testing (SAST) tools — covers features, pricing, licensing, and alternatives. No affiliate links or vendor sponsorship.