### PR TITLE
Add releaserun dependency vulnerability scanner

### DIFF
--- a/data/tools/releaserun.yml
+++ b/data/tools/releaserun.yml
@@ -12,7 +12,7 @@ license: MIT
 types:
   - cli
 source: "https://github.com/Releaserun/releaserun-cli"
-homepage: "https://releaserun.com/tools/dependency-eol-scanner/"
+homepage: "https://releaserun.com/tools/dep-eol-scanner/"
 description: >-
   CLI tool that scans project dependencies for known CVEs, end-of-life
   status, and deprecated packages across multiple ecosystems. Supports

--- a/data/tools/releaserun.yml
+++ b/data/tools/releaserun.yml
@@ -1,0 +1,22 @@
+name: releaserun
+categories:
+  - linter
+tags:
+  - security
+  - nodejs
+  - python
+  - go
+  - rust
+  - dockerfile
+license: MIT
+types:
+  - cli
+source: "https://github.com/Releaserun/releaserun-cli"
+homepage: "https://releaserun.com/tools/dependency-eol-scanner/"
+description: >-
+  CLI tool that scans project dependencies for known CVEs, end-of-life
+  status, and deprecated packages across multiple ecosystems. Supports
+  Node.js (package.json), Python (requirements.txt), Go (go.mod), Rust
+  (Cargo.toml), and Dockerfiles. Reports vulnerability severity, EOL
+  dates, and suggests upgrade paths. Available as npm package and GitHub
+  Action for CI/CD integration.


### PR DESCRIPTION
Adds [releaserun](https://github.com/Releaserun/releaserun-cli) to the Security/SAST section.

**What it does:** CLI tool that scans project dependencies for known CVEs, end-of-life status, and deprecated packages. Covers Node.js, Python, Go, Rust, and Dockerfiles.

**Why it fits:** Similar to Grype and lockfile-lint already on the list, but focused on dependency lifecycle (EOL detection, upgrade paths) alongside vulnerability scanning. Multi-ecosystem support from a single tool.

- [npm package](https://www.npmjs.com/package/releaserun) (published, MIT licensed)
- [GitHub Action](https://github.com/Releaserun/releaserun-action) for CI/CD integration
- [Web version](https://releaserun.com/tools/dependency-eol-scanner/) (free, no login)