### PR TITLE
Add axe-core and Pa11y accessibility testing tools

### DIFF
--- a/data/tools/axe-core.yml
+++ b/data/tools/axe-core.yml
@@ -1,0 +1,14 @@
+name: axe-core
+categories:
+  - linter
+tags:
+  - html
+license: MPL-2.0
+types:
+  - cli
+source: 'https://github.com/dequelabs/axe-core'
+homepage: 'https://www.deque.com/axe/'
+description: >-
+  Accessibility engine for automated Web UI testing. Tests HTML against
+  WCAG 2.0, 2.1, and 2.2 guidelines. Used by Google Lighthouse, Microsoft
+  Accessibility Insights, and thousands of organizations worldwide.

--- a/data/tools/pa11y.yml
+++ b/data/tools/pa11y.yml
@@ -1,0 +1,14 @@
+name: Pa11y
+categories:
+  - linter
+tags:
+  - html
+license: LGPL-3.0
+types:
+  - cli
+source: 'https://github.com/pa11y/pa11y'
+homepage: 'https://pa11y.org/'
+description: >-
+  Automated accessibility testing tool that runs HTML CodeSniffer or axe-core
+  from the command line. Supports CI/CD integration, multiple reporters, and
+  testing against WCAG 2.1 AA standards.


### PR DESCRIPTION
## Summary

Adds two widely-used accessibility analysis tools to the HTML category:

### [axe-core](https://github.com/dequelabs/axe-core) (15K+ ⭐)
- The industry standard for automated accessibility testing
- Tests HTML against WCAG 2.0, 2.1, and 2.2 guidelines
- Used by Google Lighthouse, Microsoft Accessibility Insights, and thousands of organizations
- MPL-2.0 license

### [Pa11y](https://github.com/pa11y/pa11y) (4.5K+ ⭐)
- Command-line accessibility testing tool for CI/CD pipelines
- Runs HTML CodeSniffer or axe-core under the hood
- Supports multiple reporters and WCAG 2.1 AA standards
- LGPL-3.0 license

## Why?

The list currently has no dedicated accessibility analysis tools despite accessibility testing being a major category of HTML static analysis. axe-core is arguably the most widely-used HTML analysis tool in the world (it powers Lighthouse's accessibility audit), and Pa11y is the go-to CLI tool for CI/CD integration.

## Format
- Added as YAML files in `data/tools/` per contribution guidelines
- Tagged with `html` 
- Both meet all requirements: actively maintained, 4K+ stars, mature projects (5+ years old)