### PR TITLE
Add diesel-guard

### DIFF
--- a/data/tools/diesel-guard.yml
+++ b/data/tools/diesel-guard.yml
@@ -1,0 +1,14 @@
+name: diesel-guard
+categories:
+  - linter
+tags:
+  - sql
+  - rust
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/ayarotsky/diesel-guard'
+homepage: 'https://github.com/ayarotsky/diesel-guard'
+description: >-
+  Linter for dangerous Postgres migration patterns in Diesel and SQLx.
+  Prevents downtime caused by unsafe schema changes.


### PR DESCRIPTION
* [x] I have not changed the `README.md` directly.

`diesel-guard` is a linter for dangerous Postgres migration patterns in `Diesel` and `SQLx` that:
- Detects operations that lock tables or cause downtime
- Provides safe alternatives for each blocking operation
- Supports safety-assured blocks for verified operations
- Extensible with custom checks


