### PR TITLE
Skip Rust build in pr-check when no tool YAML files are changed

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -41,12 +41,23 @@ jobs:
           else
             FILES=$(git diff --name-only --diff-filter=A origin/master...HEAD -- 'data/tools/*.yml' 'data/tools/*.yaml' | tr '\n' ' ')
           fi
+          FILES=$(echo "$FILES" | xargs)  # trim leading/trailing whitespace
           echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          echo "has_files=$( [ -n "$FILES" ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+
+      - name: Skip: no tool files to check
+        if: steps.changed.outputs.has_files == 'false'
+        run: |
+          mkdir -p pr-check-output
+          echo "${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.pull_request.number }}" > pr-check-output/pr_number.txt
+          echo "passed" > pr-check-output/result.txt
 
       - name: Install Rust toolchain
+        if: steps.changed.outputs.has_files == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
+        if: steps.changed.outputs.has_files == 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -58,9 +69,11 @@ jobs:
             pr-check-${{ runner.os }}-
 
       - name: Build pr-check
+        if: steps.changed.outputs.has_files == 'true'
         run: cargo build --release --manifest-path ci/Cargo.toml -p pr-check
 
       - name: Run pr-check
+        if: steps.changed.outputs.has_files == 'true'
         id: run-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

When a PR only touches `ci/**` files (no `data/tools/` YAMLs), the PR Check workflow still triggers. The existing code ran the full Rust build and binary anyway, but with no tool files to check. This caused the `pr-comment` workflow to fail with:

```
Unable to download artifact(s): Artifact not found for name: pr-check-output
```

Because `upload-artifact@v4` won't create an artifact when there are no output files, leaving `pr-comment` with nothing to download.

## Fix

- Emit a `has_files` output from the "Get changed tool files" step
- Add a "Skip: no tool files to check" step that runs when `has_files == 'false'`, writes `pr_number.txt` and `result.txt` directly — no Rust build needed
- Guard all Rust steps (toolchain, cache, build, run) with `if: steps.changed.outputs.has_files == 'true'`

The artifact is now always uploaded with at least `pr_number.txt` and `result.txt`, so the `pr-comment` download never fails. CI-only PRs also skip the full Rust compilation, making them faster.

Follow-up to #1803.