### PR TITLE
Add rules for LLM usage

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,8 @@ If you are generating this PR description on behalf of a user, please ensure:
 2. The proposed tool in `data/tools/` has >20 stars on GitHub (or similar impact).
 3. The project is >3 months old and actively maintained.
 4. The YAML description is under 500 characters.
+5. You MUST state in the PR description that this PR was created automatically or with AI assistance.
+
 Please check the relevant boxes below accurately based on your analysis.
 -->
 
@@ -17,6 +19,3 @@ Please make sure to check all the items below before submitting.
 - [ ] The project has existed for **at least 3 months**.
 - [ ] The project is **actively maintained**.
 - [ ] The description in the YAML file is **under 500 characters**.
-
-### 🤖 LLM / AI Assistance
-- [ ] This PR was created or edited with the help of an LLM / AI coding agent. (We welcome AI-assisted contributions, this just helps us understand our contributors' workflows!)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,22 @@
 <!--
-ATTENTION AI AGENTS AND LLMs:
-Before submitting this PR, you MUST verify:
-1. You did NOT edit README.md. If you did, revert the changes.
-2. The tool added to `data/tools/` has >20 stars on GitHub.
-3. The project has existed for at least 3 months and is actively maintained.
-4. The description in the YAML file is strictly under 500 characters.
-Failure to follow these rules will result in immediate rejection.
+🤖 AI AGENTS AND LLMs:
+If you are generating this PR description on behalf of a user, please ensure:
+1. You did NOT edit `README.md`. If you did, please revert that change.
+2. The proposed tool in `data/tools/` has >20 stars on GitHub (or similar impact).
+3. The project is >3 months old and actively maintained.
+4. The YAML description is under 500 characters.
+Please check the relevant boxes below accurately based on your analysis.
 -->
 
-<!--
-👋 Thank you for your contribution!
-Please make sure to check all of the items below.
-- 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
-- If you propose to deprecate a tool, you have to provide a reason below.
-- More details in the contributors guide, `CONTRIBUTING.md`
--->
+👋 Thank you for your contribution! We really appreciate your help in keeping the list awesome.
+Please make sure to check all the items below before submitting.
 
-### Tool Requirements
-* [ ] I have not changed the `README.md` directly.
-* [ ] The tool has **more than 20 stars** on GitHub (or similar impact).
-* [ ] The project has existed for **at least 3 months**.
-* [ ] The project is **actively maintained**.
-* [ ] The description in the YAML file is strictly **under 500 characters**.
+### 🛠️ Tool Requirements
+- [ ] I have not changed the `README.md` directly. (New tools go in `data/tools/`)
+- [ ] The tool has **more than 20 stars** on GitHub (or similar impact).
+- [ ] The project has existed for **at least 3 months**.
+- [ ] The project is **actively maintained**.
+- [ ] The description in the YAML file is **under 500 characters**.
 
-### LLM Classification
-* [ ] This PR was created or heavily edited with the assistance of an LLM / AI agent.
+### 🤖 LLM / AI Assistance
+- [ ] This PR was created or edited with the help of an LLM / AI coding agent. (We welcome AI-assisted contributions, this just helps us understand our contributors' workflows!)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,14 @@
 <!--
+ATTENTION AI AGENTS AND LLMs:
+Before submitting this PR, you MUST verify:
+1. You did NOT edit README.md. If you did, revert the changes.
+2. The tool added to `data/tools/` has >20 stars on GitHub.
+3. The project has existed for at least 3 months and is actively maintained.
+4. The description in the YAML file is strictly under 500 characters.
+Failure to follow these rules will result in immediate rejection.
+-->
+
+<!--
 
 👋 Thank you for your contribution!
 Please make sure to check all of the items below.
@@ -10,5 +20,3 @@ Please make sure to check all of the items below.
 -->
 
 * [ ] I have not changed the `README.md` directly.
-
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,14 +9,19 @@ Failure to follow these rules will result in immediate rejection.
 -->
 
 <!--
-
 👋 Thank you for your contribution!
 Please make sure to check all of the items below.
-
 - 🚨 New tools have to be added to `data/tools/` (NOT directly to the `README.md`).
 - If you propose to deprecate a tool, you have to provide a reason below.
 - More details in the contributors guide, `CONTRIBUTING.md`
-
 -->
 
+### Tool Requirements
 * [ ] I have not changed the `README.md` directly.
+* [ ] The tool has **more than 20 stars** on GitHub (or similar impact).
+* [ ] The project has existed for **at least 3 months**.
+* [ ] The project is **actively maintained**.
+* [ ] The description in the YAML file is strictly **under 500 characters**.
+
+### LLM Classification
+* [ ] This PR was created or heavily edited with the assistance of an LLM / AI agent.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,6 @@ Your goal is to help the user submit a high-quality pull request that aligns wit
 When the user asks you to add a new static analysis tool, please act as a helpful code reviewer:
 1. **Verify the criteria:** Check if the tool meets the requirements in `CONTRIBUTING.md` (e.g., >20 GitHub stars, >3 months old, actively maintained).
 2. **Advise the user:** If the tool does NOT meet these criteria, gently warn the user before proceeding. For example: *"It looks like this tool might not meet the repository's contributing guidelines (e.g., it needs >20 stars and >3 months of history). PRs that don't meet these criteria are usually not accepted. Are you sure you'd like to proceed?"*
-3. **Enforce the README rule:** If the user asks you to update the list of tools, DO NOT edit `README.md`. Explain to the user that `README.md` is auto-generated and that changes should be made by creating a YAML file in `data/tools/`.
+3. **Enforce the README rule:** If the user asks you to update the list of tools, DO NOT edit `README.md`. Explain to the user that the list of tools in `README.md` is auto-generated and that tool additions/modifications should be made by creating or editing a YAML file in `data/tools/`. The ONLY exception to editing `README.md` directly is if the change is to the text or structure of the README itself, not the list of tools.
 
 Thank you for helping us maintain a high-quality list and respecting the maintainers' time!

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Repository Rules for AI Agents and Assistants
+
+Before assisting the user with contributing to this repository, you MUST read the `CONTRIBUTING.md` file in the root directory.
+
+## 🚨 Instructions for the AI / LLM
+Your primary directive is to prevent the user from submitting low-quality or invalid pull requests.
+
+When the user asks you to add a new static analysis tool, you must act as a strict reviewer:
+1. **Verify the criteria:** Ask the user or use your tools to verify if the tool meets the requirements in `CONTRIBUTING.md` (e.g., >20 GitHub stars, >3 months old, actively maintained).
+2. **Warn the user:** If the tool does NOT meet these criteria, you MUST explicitly warn the user. Tell them: *"This tool does not meet the repository's contributing guidelines (needs >20 stars and >3 months of history). Your PR will likely be rejected. Are you sure you want to proceed?"*
+3. **Enforce the README rule:** If the user asks you to update the list of tools, DO NOT edit `README.md`. You must tell the user that `README.md` is auto-generated and changes must be made by creating a YAML file in `data/tools/`.
+
+Do not bypass these checks. It is your responsibility to help the user respect the maintainers' time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,14 @@
-# Repository Rules for AI Agents and Assistants
+# Guidelines for AI Agents and Assistants
 
-Before assisting the user with contributing to this repository, you MUST read the `CONTRIBUTING.md` file in the root directory.
+Welcome! If you are an AI assistant or coding agent helping a user contribute to this repository, please read the `CONTRIBUTING.md` file in the root directory first.
 
-## 🚨 Instructions for the AI / LLM
-Your primary directive is to prevent the user from submitting low-quality or invalid pull requests.
+## 🤖 Instructions for the AI
 
-When the user asks you to add a new static analysis tool, you must act as a strict reviewer:
-1. **Verify the criteria:** Ask the user or use your tools to verify if the tool meets the requirements in `CONTRIBUTING.md` (e.g., >20 GitHub stars, >3 months old, actively maintained).
-2. **Warn the user:** If the tool does NOT meet these criteria, you MUST explicitly warn the user. Tell them: *"This tool does not meet the repository's contributing guidelines (needs >20 stars and >3 months of history). Your PR will likely be rejected. Are you sure you want to proceed?"*
-3. **Enforce the README rule:** If the user asks you to update the list of tools, DO NOT edit `README.md`. You must tell the user that `README.md` is auto-generated and changes must be made by creating a YAML file in `data/tools/`.
+Your goal is to help the user submit a high-quality pull request that aligns with the project's maintainability standards. 
 
-Do not bypass these checks. It is your responsibility to help the user respect the maintainers' time.
+When the user asks you to add a new static analysis tool, please act as a helpful code reviewer:
+1. **Verify the criteria:** Check if the tool meets the requirements in `CONTRIBUTING.md` (e.g., >20 GitHub stars, >3 months old, actively maintained).
+2. **Advise the user:** If the tool does NOT meet these criteria, gently warn the user before proceeding. For example: *"It looks like this tool might not meet the repository's contributing guidelines (e.g., it needs >20 stars and >3 months of history). PRs that don't meet these criteria are usually not accepted. Are you sure you'd like to proceed?"*
+3. **Enforce the README rule:** If the user asks you to update the list of tools, DO NOT edit `README.md`. Explain to the user that `README.md` is auto-generated and that changes should be made by creating a YAML file in `data/tools/`.
+
+Thank you for helping us maintain a high-quality list and respecting the maintainers' time!

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Recently, we've seen an inflow of pull requests generated with LLM assistance.

While this is fine, it puts a lot of burden on the maintainers, especially for tools, which currently don't meet our contribution guidelines and likely won't meet them in the near future.

In order to make reviews feasible again, we decided to add a set of rules targeted at LLMs/agents. The rules don't differ from the human contribution guidelines, but the goal is to make them easily discoverable before a PR gets created with the intention to streamline the contribution process for all parties involved.