### PR TITLE
Add dig2memory - code intelligence server using tree-sitter

### DIFF
--- a/data/tools/dig2memory.yml
+++ b/data/tools/dig2memory.yml
@@ -1,0 +1,14 @@
+name: dig2memory
+categories:
+  - linter
+tags:
+  - rust
+  - typescript
+  - python
+  - go
+license: MIT
+types:
+  - cli
+  - web-service
+source: "https://github.com/ZENG3LD/dig2memory"
+description: Code intelligence server with multi-language AST indexing using tree-sitter. Provides caller tracking, dependency graphs, file-level impact analysis, crate dependency trees, and fuzzy symbol search via HTTP API.

--- a/data/tools/dig2memory.yml
+++ b/data/tools/dig2memory.yml
@@ -9,7 +9,7 @@ tags:
 license: MIT
 types:
   - cli
-  - web-service
+  - service
 source: "https://github.com/ZENG3LD/dig2memory"
 homepage: "https://github.com/ZENG3LD/dig2memory"
 description: Code intelligence server with multi-language AST indexing using tree-sitter. Provides caller tracking, dependency graphs, file-level impact analysis, crate dependency trees, and fuzzy symbol search via HTTP API.

--- a/data/tools/dig2memory.yml
+++ b/data/tools/dig2memory.yml
@@ -11,4 +11,5 @@ types:
   - cli
   - web-service
 source: "https://github.com/ZENG3LD/dig2memory"
+homepage: "https://github.com/ZENG3LD/dig2memory"
 description: Code intelligence server with multi-language AST indexing using tree-sitter. Provides caller tracking, dependency graphs, file-level impact analysis, crate dependency trees, and fuzzy symbol search via HTTP API.


### PR DESCRIPTION
Adds dig2memory, a code intelligence server with multi-language AST indexing using tree-sitter.

- **Languages**: Rust, TypeScript, Python, Go
- **Features**: caller tracking, dependency graphs, impact analysis, fuzzy symbol search
- **Interface**: HTTP API (web service) + CLI
- **License**: MIT
- **Source**: https://github.com/ZENG3LD/dig2memory