### PR TITLE
Add CodeSight

### DIFF
--- a/data/tools/codesight.yml
+++ b/data/tools/codesight.yml
@@ -1,0 +1,26 @@
+name: CodeSight
+categories:
+  - linter
+tags:
+  - python
+  - javascript
+  - typescript
+  - go
+  - rust
+  - java
+  - solidity
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/AvixoSec/codesight'
+homepage: 'https://codesight.is-a.dev'
+resources:
+  - title: Zenodo preprint - Benchmarking LLMs for Automated Code Security Analysis
+    url: https://doi.org/10.5281/zenodo.19672508
+description: >-
+  LLM-powered CLI for code review, bug detection and security analysis with
+  CWE IDs and OWASP Top 10 mapping. Supports 13+ providers via 5 adapters
+  (OpenAI, Anthropic, Google Vertex, Ollama, and any OpenAI-compatible).
+  Outputs SARIF for GitHub Security tab and CI exit codes. Benchmarked at
+  91.5% detection on 47 vulnerable samples across 14 CWEs, beats Semgrep and
+  CodeQL on logic vulnerabilities.

--- a/data/tools/codesight.yml
+++ b/data/tools/codesight.yml
@@ -8,7 +8,6 @@ tags:
   - go
   - rust
   - java
-  - solidity
 license: MIT License
 types:
   - cli


### PR DESCRIPTION
Adds CodeSight, an MIT-licensed LLM-powered CLI for automated code review, bug detection and security analysis.

- GitHub: https://github.com/AvixoSec/codesight
- PyPI: https://pypi.org/project/codesight
- Docs: https://codesight.is-a.dev
- Zenodo preprint (DOI 10.5281/zenodo.19672508): https://doi.org/10.5281/zenodo.19672508
- License: MIT
- Benchmarks: 91.5% detection on 47 vulnerable samples across 14 CWEs, 6.7% false positive rate. Beats Semgrep (12%) and CodeQL (25%) on logic-dependent vulnerabilities.
- Output: SARIF (GitHub Security tab), Markdown, JSON. GitHub Marketplace Action shipped.
- Multi-language: supports any language via LLM backends (Python, JS/TS, Go, Rust, Java, Solidity and more).

YAML entry added at data/tools/codesight.yml following the contributing guide.