### PR TITLE
feat: add nyx linter tool with multi-language support

### DIFF
--- a/data/api/tools.json
+++ b/data/api/tools.json
@@ -13141,6 +13141,45 @@
     "demos": null,
     "wrapper": null
   },
+  "nyx": {
+    "name": "nyx",
+    "categories": [
+      "linter"
+    ],
+    "languages": [
+      "c",
+      "cpp",
+      "go",
+      "java",
+      "javascript",
+      "php",
+      "python",
+      "ruby",
+      "rust",
+      "typescript"
+    ],
+    "other": [
+      "ci",
+      "security"
+    ],
+    "licenses": [
+      "GPL-3.0"
+    ],
+    "types": [
+      "cli"
+    ],
+    "homepage": "https://nyxscan.dev",
+    "source": "https://github.com/elicpeter/nyx",
+    "pricing": null,
+    "plans": null,
+    "description": "Local-first, cross-language SAST tool with cross-file taint tracking. Runs headless for CI with SARIF output, or serves findings to a local browser UI with a flow visualiser, triage workflow, and rule editor. Triage state commits alongside your code. No cloud, no account.",
+    "discussion": null,
+    "deprecated": null,
+    "resources": null,
+    "reviews": null,
+    "demos": null,
+    "wrapper": null
+  },
   "oclint": {
     "name": "oclint",
     "categories": [


### PR DESCRIPTION
## Add nyx

Adds [`nyx`](https://nyxscan.dev) ([source](https://github.com/elicpeter/nyx)), a local-first, cross-language SAST tool with cross-file taint tracking.

**Languages:** Python, JavaScript, TypeScript, Java, PHP, Ruby, Rust, Go, C, C++

**What it does:** Runs taint analysis headless for CI (SARIF output, GitHub Code Scanning compatible) or serves findings to a local browser UI with a flow visualiser, triage workflow, and custom rule editor. Triage state persists to `.nyx/triage.json` and commits alongside your code. No cloud, no account required.

### 🛠️ Tool Requirements
- [x] I have not changed the `README.md` directly. (New tools go in `data/tools/`)
- [x] The tool has **more than 20 stars** on GitHub (or similar impact).
- [x] The project has existed for **at least 3 months**.
- [x] The project is **actively maintained**.
- [x] The description in the YAML file is **under 500 characters**.
