### PR TITLE
Add zizmor static analysis tool

### DIFF
--- a/data/tools/zizmor.yml
+++ b/data/tools/zizmor.yml
@@ -1,0 +1,13 @@
+name: zizmor
+categories:
+  - linter
+tags:
+  - ci
+  - security
+  - yaml
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/zizmorcore/zizmor'
+homepage: 'https://zizmor.sh'
+description: 'Static analysis for GitHub Actions workflows, detecting insecure CI/CD patterns such as excessive token permissions, template injection risks, credential persistence, and unsafe workflow references.'


### PR DESCRIPTION
## Summary
- add zizmor to the static analysis tool catalog
- classify it under CI, security, and YAML workflow analysis

## Rationale
zizmor is a maintained open-source scanner for GitHub Actions workflow security. It helps identify risky CI/CD patterns such as excessive token permissions, template injection exposure, credential persistence, and unsafe workflow references.

## Validation
- added a single tool entry under data/tools/
- followed the repository's contribution format
- local render was not run because Rust/Cargo is not installed in this workstation environment