### PR TITLE
Add GauntletCI to static analysis tools list

### DIFF
--- a/data/tools/GauntletCI.yml
+++ b/data/tools/GauntletCI.yml
@@ -1,0 +1,16 @@
+name: GauntletCI
+categories:
+  - static analysis
+  - diff-based analysis
+tags:
+  - csharp
+  - dotnet
+  - ci
+  - pre-commit
+license: MIT license
+types:
+  - cli
+source: 'https://github.com/EricCogen/GauntletCI'
+homepage: 'https://gauntletci.com'
+description: >-
+  Deterministic pre-commit change-risk detection for .NET. GauntletCI analyzes only the lines you changed (diff-based), not the entire codebase. It detects behavioral regressions, breaking changes, and risk patterns invisible to traditional linters and tests. Runs locally in sub-second time, high-signal output with zero configuration required. Integrates as pre-commit hook, GitHub Actions workflow, or local CLI.

--- a/data/tools/GauntletCI.yml
+++ b/data/tools/GauntletCI.yml
@@ -1,7 +1,6 @@
 name: GauntletCI
 categories:
-  - static analysis
-  - diff-based analysis
+  - linter
 tags:
   - csharp
   - dotnet

--- a/data/tools/GauntletCI.yml
+++ b/data/tools/GauntletCI.yml
@@ -1,6 +1,7 @@
 name: GauntletCI
 categories:
-  - linter
+  - static analysis
+  - diff-based analysis
 tags:
   - csharp
   - dotnet


### PR DESCRIPTION
GauntletCI is a deterministic pre-commit change-risk detection tool for .NET:

- **Diff-based analysis**: Analyzes only the lines you changed, not the entire codebase
- **Detects behavioral regressions**: Catches risk patterns invisible to traditional linters and tests  
- **Sub-second performance**: Runs locally with zero configuration required
- **Multiple integration points**: Pre-commit hook, GitHub Actions workflow, or local CLI
- **Open source**: MIT licensed
- **Website**: https://gauntletci.com

This tool complements traditional static analysis by focusing on risks that emerge from code changes themselves, rather than individual lines in isolation.