### PR TITLE
Add vastlint to Multiple languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1629,6 +1629,8 @@ orchestration to ensure zero breaking changes. Specialized for React, Next.js, a
 
 - [Veracode](https://www.veracode.com/security/static-code-analysis) :copyright: — Find flaws in binaries and bytecode without requiring source. Support all major programming languages: Java, .NET, JavaScript, Swift, Objective-C, C, C++ and more.
 
+- [vastlint](https://github.com/aleksUIX/vastlint) — Validator and linter for VAST XML ad tags. Checks wrappers and inline tags against the IAB VAST 2.0-4.3 specification and can auto-fix deterministic issues.
+
 - [WALA](https://github.com/wala/WALA) — Static analysis capabilities for Java bytecode and related languages and for JavaScript.
 
 - [weggli](https://github.com/googleprojectzero/weggli) — A fast and robust semantic search tool for C and C++ codebases. It is designed to help security researchers identify interesting functionality in large codebases.

--- a/data/tools/vastlint.yml
+++ b/data/tools/vastlint.yml
@@ -1,0 +1,14 @@
+name: vastlint
+categories:
+  - linter
+tags:
+  - xml
+license: proprietary
+types:
+  - cli
+  - service
+homepage: "https://vastlint.org"
+description: >-
+  Validator and linter for VAST XML ad tags. Checks wrappers and inline tags
+  against the IAB VAST 2.0-4.3 specification and can auto-fix deterministic
+  issues.


### PR DESCRIPTION
## Summary
- add vastlint to the Multiple languages section

## Why
- vastlint is a validator/linter for VAST XML ad tags
- it validates wrappers and inline tags against the IAB VAST 2.0-4.3 specification
- it also supports deterministic auto-fixes for some issues, which makes it a reasonable fit for this collection of static analysis tools

## Disclosure
- I maintain vastlint, so this is a self-submission rather than a third-party recommendation.
