### PR TITLE
Add golangci-lint to Go tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 | [Ada](#ada) | [F#](#fsharp) | [Perl](#perl) |
 | [Assembly](#asm) | [Fortran](#fortran) | [Python](#python) |
 | [Awk](#awk) | [Go](#go) | [R](#r) |
+- [golangci-lint](https://github.com/golangci/lint) - Fast linters runner for Go.
 | [C](#c) | [Groovy](#groovy) | [Rego](#rego) |
 | [C#](#csharp) | [Haskell](#haskell) | [Ruby](#ruby) |
 | [C++](#cpp) | [Haxe](#haxe) | [Rust](#rust) |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Also check out the sister project, [awesome-dynamic-analysis](https://github.com
 | [Ada](#ada) | [F#](#fsharp) | [Perl](#perl) |
 | [Assembly](#asm) | [Fortran](#fortran) | [Python](#python) |
 | [Awk](#awk) | [Go](#go) | [R](#r) |
-- [golangci-lint](https://github.com/golangci/lint) - Fast linters runner for Go.
 | [C](#c) | [Groovy](#groovy) | [Rego](#rego) |
 | [C#](#csharp) | [Haskell](#haskell) | [Ruby](#ruby) |
 | [C++](#cpp) | [Haxe](#haxe) | [Rust](#rust) |

--- a/data/tools/golangci-lint.yml
+++ b/data/tools/golangci-lint.yml
@@ -8,7 +8,9 @@ types:
   - cli
 source: "https://github.com/golangci/golangci-lint"
 homepage: "https://golangci-lint.run"
-description: "Alternative to `Go Meta Linter`: GolangCI-Lint is a linters aggregator."
+description: "Fast linters runner for Go. It aggregates multiple Go linters and provides a unified configuration, caching, and output format. Alternative to `Go Meta Linter`."
+reviews:
+  - https://stackshare.io/golangci-lint
 resources:
   - title: "GopherCon 2019: Denis Isaev (author of golangci-lint) - Go Linters: Myths and Best Practices"
     url: https://www.youtube.com/watch?v=1U-Gzz4TYP0


### PR DESCRIPTION
Added golangci-lint - standard Go linter. 16k+ stars.