### PR TITLE
add go-mutesting

### DIFF
--- a/data/tools/go-mutesting.yml
+++ b/data/tools/go-mutesting.yml
@@ -1,0 +1,15 @@
+name: go-mutesting
+categories:
+  - linter
+tags:
+  - go
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/jonbaldie/go-mutesting'
+homepage: 'https://jonbaldie.github.io/go-mutesting/'
+description: >-
+  Mutation testing for Go. Applies code mutations (arithmetic, branch, expression,
+  loop, statement, concurrency, and more) and checks whether tests catch them.
+  Reports a mutation score index (MSI) with CI quality gates, per-test filtering,
+  parallel execution, and JSON output designed for LLM consumption.


### PR DESCRIPTION
Adds [go-mutesting](https://github.com/jonbaldie/go-mutesting) — a mutation testing tool for Go.

It applies code mutations across arithmetic, branch, expression, loop, statement, and concurrency operators, then runs your test suite to see which mutations survive. Reports a mutation score (MSI) and supports CI quality gates, parallel execution, per-test filtering, and JSON output.

Docs site: https://jonbaldie.github.io/go-mutesting/

Note: the repo has 2 stars right now — it's a recently published fork of the dormant avito-tech/go-mutesting, which itself forked the original zimmski tool. Happy to discuss if that's a blocker.