### PR TITLE
Add pgrls (Postgres Row-Level Security static analyzer)

### DIFF
--- a/data/tools/pgrls.yml
+++ b/data/tools/pgrls.yml
@@ -1,0 +1,22 @@
+name: pgrls
+categories:
+  - linter
+tags:
+  - sql
+  - security
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/pgrls/pgrls'
+homepage: 'https://github.com/pgrls/pgrls'
+description: |
+  Static analyzer for Postgres Row-Level Security. Connects to a live
+  database, walks the parsed AST of every policy predicate (via pglast),
+  and reports auth bugs, predicate logic flaws, and per-row performance
+  traps. 36 rules across security (SEC001-SEC026), performance
+  (PERF001-PERF003), hygiene (HYG001-HYG003), and view bypasses
+  (VIEW001-VIEW004); 10 mechanically auto-fixable via `pgrls fix`.
+  A `pgrls diff` command classifies migrations as SAFE / BREAKING /
+  REQUIRES_REVIEW / DANGEROUS so CI gates on real security regressions
+  without blocking safe schema changes. Output formats: text, JSON,
+  SARIF, Markdown.


### PR DESCRIPTION
Adds **pgrls** — https://github.com/pgrls/pgrls — a static analyzer for Postgres Row-Level Security.

## What pgrls does

pgrls connects to a live Postgres database, walks the parsed AST of every RLS policy predicate (via [pglast](https://github.com/lelit/pglast) / `pg_query`), and reports auth bugs, predicate logic flaws, and per-row performance traps. The current release ships **36 lint rules** across four categories — security (SEC001–SEC026), per-row performance (PERF001–PERF003), hygiene (HYG001–HYG003), and view-mediated bypasses (VIEW001–VIEW004). **10 rules are mechanically auto-fixable** via `pgrls fix`, which emits ready-to-apply SQL (`ALTER POLICY …`, `ALTER TABLE … FORCE ROW LEVEL SECURITY`, etc.). Output formats include text, JSON, SARIF, and Markdown.

A `pgrls diff` command compares two Postgres sources and classifies every change as SAFE / BREAKING / REQUIRES_REVIEW / DANGEROUS so CI can gate merges on real security regressions without blocking safe schema migrations.

## Format

- File: `data/tools/pgrls.yml`
- Categories: `linter`
- Tags: `sql`, `security`
- License: MIT (OSI-approved, FSF-listed)
- Types: `cli`

## Adoption / maturity (transparent about the soft criteria)

The contributing guide lists three soft requirements; I want to be upfront on where pgrls lands:

- **License:** MIT, OSI-approved — ✓
- **Actively maintained:** very actively (CHANGELOG covers v0.2 → v0.5.46, multiple weekly releases), but with one core contributor at the moment.
- **Actively used:** ~2,400 PyPI downloads per month against ~5 GitHub stars — adoption is happening primarily through CI/automation rather than GitHub awareness. Happy for the maintainer to weigh "actively used" using either signal.
- **Mature (3+ months):** project is ~4 weeks old (first commit 2026-04-24). Below the formal threshold. I'm submitting now because the surface area is already stable (36 rules, complete test/CI coverage across PG15–17, JSON/SARIF schema documented as the public contract); happy to revisit if you'd prefer to wait until 2026-07-24.

Mentioning this so you can apply your judgement. If the maturity gap is a blocker, please feel free to close with a "resubmit in July" note and I'll be back on the dot.