### PR TITLE
Add proof-of-commitment — supply chain risk scoring

### DIFF
--- a/data/tools/proof-of-commitment.yml
+++ b/data/tools/proof-of-commitment.yml
@@ -1,0 +1,23 @@
+name: proof-of-commitment
+categories:
+  - linter
+tags:
+  - javascript
+  - typescript
+  - python
+  - rust
+  - go
+  - security
+  - package
+license: MIT
+types:
+  - cli
+  - web
+source: 'https://github.com/piiiico/proof-of-commitment'
+homepage: 'https://getcommit.dev'
+description: >-
+  Supply chain risk scoring for npm packages, PyPI packages, Rust crates, Go modules,
+  and GitHub repos. Scores packages on behavioral commitment signals —
+  publisher concentration, transfer history, contributor counts — that
+  traditional vulnerability scanners miss. Run with `npx proof-of-commitment`
+  to audit your project's dependencies.

--- a/data/tools/proof-of-commitment.yml
+++ b/data/tools/proof-of-commitment.yml
@@ -12,7 +12,6 @@ tags:
 license: MIT
 types:
   - cli
-  - web
 source: 'https://github.com/piiiico/proof-of-commitment'
 homepage: 'https://getcommit.dev'
 description: >-


### PR DESCRIPTION
## What

Adds [proof-of-commitment](https://github.com/piiiico/proof-of-commitment) as a supply chain security analysis tool.

## Why it fits

Supply chain risk is a growing SAST/SCA concern. This tool scores npm packages, PyPI packages, Rust crates, Go modules, and GitHub repos on **behavioral commitment signals** — publisher count, transfer history, contributor concentration — that traditional vulnerability scanners (which look for CVEs) don't cover.

Similar tools already in the list: Semgrep Supply Chain, OWASP Dependency Check.

## Usage

```bash
npx proof-of-commitment             # auto-detects package.json / lockfile
npx proof-of-commitment zod axios chalk
```

Also available as a web tool: https://getcommit.dev

## Tool metadata

- License: MIT
- Type: CLI + web
- Languages: JavaScript/TypeScript, Python, Rust, Go
- Category: supply chain / dependency security analysis