### PR TITLE
Add proof-of-commitment supply chain risk scorer

### DIFF
--- a/data/tools/proof-of-commitment.yml
+++ b/data/tools/proof-of-commitment.yml
@@ -1,0 +1,20 @@
+name: proof-of-commitment
+categories:
+  - linter
+tags:
+  - security
+  - package
+  - nodejs
+  - python
+  - rust
+license: MIT
+types:
+  - cli
+  - service
+source: 'https://github.com/piiiico/proof-of-commitment'
+homepage: 'https://getcommit.dev'
+description: >-
+  Behavioral risk scoring for npm, PyPI, Cargo, and Go packages. Surfaces
+  publisher concentration, release consistency, and maintenance patterns that
+  predict supply chain attacks. Available as CLI, MCP server, GitHub Action,
+  and IDE hooks for Cursor and Claude Code.

--- a/data/tools/proof-of-commitment.yml
+++ b/data/tools/proof-of-commitment.yml
@@ -4,6 +4,7 @@ categories:
 tags:
   - security
   - package
+  - javascript
   - nodejs
   - python
   - rust


### PR DESCRIPTION
Adds proof-of-commitment as a new tool entry.

**Category:** Security/SAST — supply chain risk scoring  
**Tags:** security, package, nodejs, python, rust  
**License:** MIT

**What it does:** Scores npm, PyPI, Cargo, and Go packages on behavioral trust signals — publisher concentration, release consistency, maintenance patterns. Predicted CRITICAL risk for axios and LiteLLM before their 2026 supply chain attacks.

Complements existing tools like lockfile-lint (lockfile analysis) and OSV-Scanner (vulnerability matching) by adding behavioral risk scoring that catches publisher-concentration risk invisible to CVE databases.

**Formats:** CLI (`npx proof-of-commitment`), MCP server (streamable HTTP), GitHub Action, REST API.  
**Homepage:** https://getcommit.dev  
**Source:** https://github.com/piiiico/proof-of-commitment