### PR TITLE
Add adocfmt

### DIFF
--- a/data/api/tags.json
+++ b/data/api/tags.json
@@ -353,6 +353,11 @@
       "tag_type": "Other"
     },
     {
+      "name": "AsciiDoc",
+      "value": "asciidoc",
+      "tag_type": "Other"
+    },
+    {
       "name": "Ansible",
       "value": "ansible",
       "tag_type": "Other"

--- a/data/api/tools.json
+++ b/data/api/tools.json
@@ -111,6 +111,37 @@
     "demos": null,
     "wrapper": null
   },
+  "adocfmt": {
+    "name": "adocfmt",
+    "categories": [
+      "linter",
+      "formatter"
+    ],
+    "languages": [
+      "java"
+    ],
+    "other": [
+      "asciidoc",
+      "writing"
+    ],
+    "licenses": [
+      "Apache License 2.0"
+    ],
+    "types": [
+      "cli"
+    ],
+    "homepage": "https://github.com/dheid/adocfmt",
+    "source": "https://github.com/dheid/adocfmt",
+    "pricing": null,
+    "plans": null,
+    "description": "An opinionated formatter for AsciiDoc documents that normalizes headings, lists, block delimiters, and whitespace. Includes a check mode for CI pipelines. Distributed as a CLI with integrations for pre-commit, GitHub Actions, and the Spotless code-formatting plugin.",
+    "discussion": null,
+    "deprecated": null,
+    "resources": null,
+    "reviews": null,
+    "demos": null,
+    "wrapper": null
+  },
   "aether": {
     "name": "aether",
     "categories": [
@@ -3561,7 +3592,7 @@
     "plans": null,
     "description": "Static Code Analysis for R.",
     "discussion": null,
-    "deprecated": null,
+    "deprecated": true,
     "resources": null,
     "reviews": null,
     "demos": null,
@@ -12236,7 +12267,7 @@
     "plans": null,
     "description": "Format markdown code blocks using your favorite code formatters.",
     "discussion": null,
-    "deprecated": null,
+    "deprecated": false,
     "resources": null,
     "reviews": null,
     "demos": null,
@@ -13938,7 +13969,7 @@
     "plans": null,
     "description": "Facebook's tools for code analysis, visualizations, or style-preserving source transformation for many languages.",
     "discussion": null,
-    "deprecated": null,
+    "deprecated": true,
     "resources": null,
     "reviews": null,
     "demos": null,

--- a/data/tags.yml
+++ b/data/tags.yml
@@ -10,6 +10,9 @@
 - name: ActionScript
   value: actionscript
   type: language
+- name: AsciiDoc
+  value: asciidoc
+  type: other
 - name: Active Server Pages
   value: asp
   type: language

--- a/data/tools/adocfmt.yml
+++ b/data/tools/adocfmt.yml
@@ -1,0 +1,18 @@
+name: adocfmt
+categories:
+  - formatter
+  - linter
+tags:
+  - asciidoc
+  - java
+  - writing
+license: Apache License 2.0
+types:
+  - cli
+source: "https://github.com/dheid/adocfmt"
+homepage: "https://dheid.github.io/adocfmt"
+description: >-
+  An opinionated formatter for AsciiDoc documents that normalizes headings,
+  lists, block delimiters, and whitespace. Includes a check mode for CI
+  pipelines. Distributed as a CLI with integrations for pre-commit, GitHub
+  Actions, and the Spotless code-formatting plugin.


### PR DESCRIPTION
This adds [adocfmt](https://github.com/dheid/adocfmt), an open-source (Apache-2.0) opinionated formatter for AsciiDoc documents.

It normalizes headings, lists, block delimiters and whitespace, and has a check mode for CI. It is distributed as a CLI and integrates with pre-commit, GitHub Actions, and Spotless. Most existing AsciiDoc tooling lints but does not auto-fix,
so this fills the formatter gap.

I ran `make render` locally without errors.