### PR TITLE
Add BrassCoders — deterministic local pre-merge gate for AI-generated Python

### DIFF
--- a/data/tools/brasscoders.yml
+++ b/data/tools/brasscoders.yml
@@ -1,0 +1,18 @@
+name: BrassCoders
+categories:
+  - linter
+tags:
+  - python
+  - ci
+  - security
+license: Apache-2.0
+types:
+  - cli
+source: "https://github.com/CopperSunDev/brasscoders"
+homepage: "https://coppersun.dev"
+description: >-
+  Deterministic local pre-merge gate for AI-generated Python code: orchestrates 12 scanners
+  (Bandit, Pylint, Pyre/Pysa, Semgrep, detect-secrets, and custom performance and privacy
+  detectors) and emits ranked findings as YAML for AI coding assistants to consume.
+  Catches AI-coder performance anti-patterns (O(N²) string concat, insert-at-zero loops,
+  N-deep nested joins, unbounded polls) that generic security linters miss.


### PR DESCRIPTION
## What is BrassCoders?

BrassCoders is a deterministic, local, free pre-merge CLI that orchestrates 12 static-analysis scanners and emits ranked findings as YAML for AI coding assistants. Apache 2.0, distributed via PyPI as `brasscoders`, requires Python 3.10+.

**Scanners bundled:** Bandit, Pylint, Pyre/Pysa (taint), Semgrep, ast-grep, detect-secrets (Yelp), plus six custom scanners for performance anti-patterns, secrets, PII, AI-pattern detection, content moderation, and JavaScript/TypeScript.

**The distinctive coverage:** four AST-level rules that catch the performance anti-patterns AI coding assistants reliably introduce — O(N²) string concatenation in loops, `list.insert(0)` in loops, N-deep nested loops used as joins, and unbounded `while True` polls — which Bandit, Pylint, and Semgrep have no rules for.

**Reproducibility:** same scan on same code produces identical output every run. Designed as a CI gate (`brasscoders --offline scan`), not an advisory tool.

- **Source:** https://github.com/CopperSunDev/brasscoders
- **PyPI:** https://pypi.org/project/brasscoders/
- **License:** Apache-2.0
- **Homepage:** https://coppersun.dev

Benchmark data (12 AI-generated Python files, one planted bug each): BrassCoders 11/12, Bandit 6/12, Pylint 1/12, frontier model 12/12. Wedge: BrassCoders 4/4 on AI-coder perf anti-patterns; all others 0/4.