### PR TITLE
Add SkillTotal (static security scanner for AI components)

### DIFF
--- a/data/tools/skilltotal.yml
+++ b/data/tools/skilltotal.yml
@@ -1,0 +1,23 @@
+name: SkillTotal
+categories:
+  - linter
+tags:
+  - python
+  - javascript
+  - nodejs
+  - json
+  - ci
+  - security
+license: Apache License 2.0
+types:
+  - cli
+source: 'https://github.com/pezhik/skilltotal'
+homepage: 'https://www.skilltotal.ai'
+description: >-
+  A free, offline static security scanner for AI components
+  (agent skills/plugins, MCP servers, npm & PyPI packages, git repos).
+  Deterministic regex + AST detection (no LLM, no account) with
+  evidence-anchored findings for supply-chain risk, dangerous
+  capabilities, prompt-injection surfaces, MCP tool poisoning and
+  exfiltration paths; maps to the OWASP Agentic Skills Top 10.
+  JSON and SARIF 2.1.0 output, with a GitHub Action and pre-commit hook.


### PR DESCRIPTION
This adds a new tool entry at `data/tools/skilltotal.yml` (README left untouched, per CONTRIBUTING). SkillTotal is a free, Apache-2.0, offline static security scanner for AI components (agent skills/plugins, MCP servers, npm & PyPI packages, git repos) using deterministic regex + AST detection with no LLM and no account. All tags are drawn from `data/tags.yml`, and it emits evidence-anchored findings as JSON and SARIF 2.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)