### PR TITLE
Add code-inspector

### DIFF
--- a/data/tools/code-inspector.yml
+++ b/data/tools/code-inspector.yml
@@ -1,0 +1,28 @@
+name: code-inspector
+categories:
+  - linter
+tags:
+  - go
+  - python
+  - javascript
+  - typescript
+  - rust
+  - java
+  - c
+  - cpp
+  - csharp
+  - ruby
+  - php
+  - scala
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/miguelbravo7/code-inspector'
+homepage: 'https://github.com/miguelbravo7/code-inspector'
+description: >-
+  A Go CLI and library that ranks code by complexity x git churn to surface
+  refactoring hotspots. Reports cyclomatic and cognitive complexity, Halstead
+  metrics and a Maintainability Index, token-normalized duplicate-code (clone)
+  detection, and an import dependency graph (fan-in/fan-out and cycle detection)
+  across many languages via tree-sitter. Also ships a Claude Code skill for
+  AI-assisted code review.


### PR DESCRIPTION
Adds **code-inspector** — an open-source (MIT) Go CLI and library that reports code-quality metrics across many languages.

It is closest in spirit to `lizard`/`gocyclo` already in the list, but combines several metrics in one tool:

- Cyclomatic and cognitive complexity (per function), Halstead measures, and a Maintainability Index
- Token-normalized duplicate/clone detection
- Import dependency graph (fan-in/fan-out + cycle detection)
- Complexity × git-churn "hotspot" ranking to prioritize refactoring
- Multi-language via tree-sitter (Go, Python, JS/TS, Rust, Java, C/C++, C#, Ruby, PHP, Scala, …), plus a registration API for any other grammar

Source: https://github.com/miguelbravo7/code-inspector

Added `data/tools/code-inspector.yml` following the existing schema (mirrors `lizard.yml`: name, categories, tags, license, types, source, homepage, description). Disclosure: I'm the author — happy to adjust tags/category/wording to fit the list's conventions.