### PR TITLE
Add sql-sop (rule-based SQL linter)

### DIFF
--- a/data/tools/sql-sop.yml
+++ b/data/tools/sql-sop.yml
@@ -1,0 +1,14 @@
+name: sql-sop
+categories:
+  - linter
+tags:
+  - sql
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/Pawansingh3889/sql-guard'
+homepage: 'https://pypi.org/project/sql-sop/'
+description: Rule-based SQL linter with a libCST injection scanner, SARIF output, a pre-commit hook and a GitHub Action.
+resources:
+  - title: Browser playground (runs locally via Pyodide)
+    url: https://pawansingh3889.github.io/sql-guard/


### PR DESCRIPTION
Adds **sql-sop**, an open-source (MIT) rule-based SQL linter on PyPI.

It checks SQL with configurable rules, ships a libCST-based injection scanner, SARIF output, inline disable directives, and runs as a CLI, a pre-commit hook or a GitHub Action. ~500 downloads/month on PyPI, and there's a browser playground that runs entirely client-side via Pyodide.

- PyPI: https://pypi.org/project/sql-sop/
- Source: https://github.com/Pawansingh3889/sql-guard
- Playground: https://pawansingh3889.github.io/sql-guard/

Added as `data/tools/sql-sop.yml`, following the existing format (e.g. `sqlfluff.yml`).
