### PR TITLE
Add DepWarden — free SCA + SAST scanner (15 languages, no account)

### DIFF
--- a/data/tools/depwarden.yml
+++ b/data/tools/depwarden.yml
@@ -2,20 +2,24 @@ name: DepWarden
 categories:
   - linter
 tags:
-  - cargo
   - ci
   - configmanagement
   - dockerfile
+  - dotnet
   - go
   - java
   - javascript
   - json
+  - kotlin
   - kubernetes
   - php
   - python
   - ruby
   - rust
+  - scala
   - security
+  - shell
+  - swift
   - terraform
   - typescript
   - yaml

--- a/data/tools/depwarden.yml
+++ b/data/tools/depwarden.yml
@@ -1,0 +1,33 @@
+name: DepWarden
+categories:
+  - linter
+tags:
+  - cargo
+  - ci
+  - configmanagement
+  - dockerfile
+  - go
+  - java
+  - javascript
+  - json
+  - kubernetes
+  - php
+  - python
+  - ruby
+  - rust
+  - security
+  - terraform
+  - typescript
+  - yaml
+license: MIT
+types:
+  - cli
+  - service
+source: "https://github.com/Rushabh5000/dep-warden"
+homepage: "https://depwarden.in"
+description: >-
+  Free, anonymous SCA + SAST scanner. SCA: scans npm, PyPI,
+  Maven, Go, Cargo, Ruby, NuGet dependencies for CVEs (OSV/KEV/EPSS),
+  typosquats and supply-chain risk. SAST: pattern + taint analysis
+  for 15 languages, 300+ rules. No account, no source upload.
+  Available as a web tool, zero-install CLI and GitHub Action.

--- a/data/tools/depwarden.yml
+++ b/data/tools/depwarden.yml
@@ -23,11 +23,10 @@ tags:
   - terraform
   - typescript
   - yaml
-license: MIT
+license: proprietary
 types:
   - cli
   - service
-source: "https://github.com/Rushabh5000/dep-warden"
 homepage: "https://depwarden.in"
 description: >-
   Free, anonymous SCA + SAST scanner. SCA: scans npm, PyPI,


### PR DESCRIPTION
## What is DepWarden?

[DepWarden](https://depwarden.in) is a free, anonymous SCA + SAST security scanner available as a web tool, zero-install CLI (`npx depwarden`) and GitHub Action.

**SCA (Software Composition Analysis):**
- Scans npm, PyPI, Maven, Gradle, Go, Cargo, Ruby, .NET, PHP, Dart, Swift dependencies
- Vulnerability data from OSV, enriched with CISA KEV (active exploitation) and FIRST EPSS (exploit probability)
- Typosquatting and dependency confusion detection
- End-of-life package detection, OpenSSF Scorecard health, license compliance

**SAST (Static Application Security Testing):**
- 15 languages: JavaScript, TypeScript, Python, Java, Go, PHP, Ruby, C, C++, C#, Rust, Kotlin, Swift, Shell, Scala
- IaC: Terraform/HCL, Dockerfile, Kubernetes YAML, GitHub Actions
- 300+ rules: injection (taint analysis), hardcoded secrets, weak cryptography, framework misconfigurations

**Key differentiator:** No account required, no source upload — manifest text and source zip only, processed in an isolated workspace.

## Links
- Source: https://github.com/Rushabh5000/dep-warden
- Homepage: https://depwarden.in
- License: MIT