### PR TITLE
Add scythe

### DIFF
--- a/data/tools/scythe.yml
+++ b/data/tools/scythe.yml
@@ -1,0 +1,11 @@
+name: scythe
+categories:
+  - linter
+tags:
+  - sql
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/Goldziher/scythe'
+homepage: 'https://github.com/Goldziher/scythe'
+description: 'Polyglot SQL compiler and linter that generates type-safe code from SQL with schema-aware linting.'


### PR DESCRIPTION
Adds **scythe** as `data/tools/scythe.yml`.

polylint has been split out of this PR as requested and is not being resubmitted yet — it is still below the star and contributor thresholds.

### Tool requirements

- [ ] The tool is at least six months old. — created 2026-04-04, so it clears six months on **2026-10-04**. Happy to leave this open until then or reopen closer to the date, whichever you prefer.
- [x] The tool has at least 20 GitHub stars. — 66
- [x] The tool has more than one contributor. — 7
- [x] The description is no longer than 500 characters.
- [x] I have not changed `README.md` directly.

### AI tags, if applicable

Neither tag applies: scythe is a deterministic SQL compiler/linter and does not invoke an LLM.
