### PR TITLE
Add Bytebase (SQL Review linter) to the SQL tag

### DIFF
--- a/data/tools/bytebase.yml
+++ b/data/tools/bytebase.yml
@@ -1,0 +1,19 @@
+name: Bytebase
+categories:
+  - linter
+tags:
+  - sql
+license: Other
+types:
+  - gui
+  - service
+source: 'https://github.com/bytebase/bytebase'
+homepage: 'https://www.bytebase.com'
+description: >-
+  Database DevSecOps platform with a built-in SQL Review engine that lints
+  schema migrations and queries against 100+ configurable rules — naming
+  conventions, anti-patterns, and safety checks — across MySQL, PostgreSQL,
+  Oracle, SQL Server, Snowflake, and more.
+resources:
+  - title: SQL Review documentation
+    url: https://www.bytebase.com/docs/sql-review/


### PR DESCRIPTION
Adds **Bytebase** under the `sql` tag.

Bytebase is an open-source database DevSecOps platform (14k+ stars) whose **SQL Review** engine is a configurable SQL linter: it checks schema migrations and queries against 100+ rules covering naming conventions, anti-patterns, and safety, across MySQL, PostgreSQL, Oracle, SQL Server, Snowflake, and more. It fits alongside the existing SQL tools (SQLFluff, sqlcheck, sqlint).

- Source: https://github.com/bytebase/bytebase
- Homepage: https://www.bytebase.com
- SQL Review docs: https://www.bytebase.com/docs/sql-review/

Categories: `linter` · Types: `gui`, `service` · License: Other (open source; enterprise-licensed portions).
