### PR TITLE
docs: add squirrelscan

### DIFF
--- a/data/tools/squirrelscan.yml
+++ b/data/tools/squirrelscan.yml
@@ -7,10 +7,12 @@ tags:
   - html
   - javascript
   - security
-license: proprietary
+  - uses-llm
+license: MIT
 types:
   - cli
   - service
+source: 'https://github.com/squirrelscan/squirrelscan'
 homepage: 'https://squirrelscan.com'
 description: >-
   squirrelscan is a website QA tool built for coding agents such as Claude Code

--- a/data/tools/squirrelscan.yml
+++ b/data/tools/squirrelscan.yml
@@ -1,0 +1,20 @@
+name: squirrelscan
+categories:
+  - linter
+tags:
+  - ci
+  - css
+  - html
+  - javascript
+  - security
+license: proprietary
+types:
+  - cli
+  - service
+homepage: 'https://squirrelscan.com'
+description: >-
+  squirrelscan is a website QA tool built for coding agents such as Claude Code
+  and Cursor. Its squirrel CLI crawls a live site and runs 260+ audit rules
+  across SEO, performance, security, accessibility, structured data and agent
+  experience, then returns exact source-mapped fixes. Runs from the terminal,
+  CI, the cloud, or over MCP.


### PR DESCRIPTION
Adds **squirrelscan**, a website QA tool for coding agents whose `squirrel` CLI crawls a live site and runs 260+ audit rules across SEO, performance, security, accessibility, structured data and agent experience, returning source-mapped fixes.

Fits alongside existing URL/rendered-page and web linters in the list (e.g. Pa11y, HTMLHint, Stylelint). Tagged `html`, `css`, `javascript`, `security`, `ci`; category `linter`.

- Homepage: https://squirrelscan.com
- License: proprietary
- Types: cli, service

Closed-source (proprietary), so `source` is omitted, matching other proprietary service entries (Snyk Code, DeepSource, Codacy).