### PR TITLE
Add AST Metrics

### DIFF
--- a/data/tools/ast-metrics.yml
+++ b/data/tools/ast-metrics.yml
@@ -1,0 +1,25 @@
+name: AST Metrics
+categories:
+  - linter
+tags:
+  - csharp
+  - go
+  - java
+  - php
+  - python
+  - rust
+  - typescript
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/ast-metrics/ast-metrics'
+homepage: 'https://ast-metrics.dev'
+description: >-
+  Multi-language maintainability analyzer. Computes cyclomatic and cognitive
+  complexity, Halstead volume, afferent/efferent coupling and maintainability
+  index, detects communities in the dependency graph, and generates an
+  explorable HTML report plus JSON, Markdown, SARIF and OpenMetrics output.
+  Single fast binary with no runtime dependency, and a built-in MCP server so AI
+  agents can query codebase structure before refactoring.
+demos:
+  - https://analyze.ast-metrics.dev


### PR DESCRIPTION
Hi! Thanks for maintaining this list, it has been a genuinely useful reference for me over the years.

This adds [AST Metrics](https://github.com/ast-metrics/ast-metrics), a multi-language code maintainability analyzer.

It is not a linter in the correctness sense: instead of reporting rule violations, it computes maintainability metrics that most linters do not cover (cyclomatic and cognitive complexity, Halstead volume, afferent/efferent coupling, maintainability index) and detects communities in the dependency graph. Output formats: explorable HTML report, plus JSON, Markdown, SARIF and OpenMetrics for CI.

It ships as a single Go binary with no runtime dependency, so analyzing PHP or Python does not require a PHP or Python installation (parsing is done with tree-sitter). It also embeds an MCP server, so AI coding agents can query codebase structure and risk areas.

Languages supported today: Go, PHP, Python, Rust, Java, C#, TypeScript.

- Source: https://github.com/ast-metrics/ast-metrics
- Homepage: https://ast-metrics.dev
- Online demo, no install: https://analyze.ast-metrics.dev
- License: MIT

Disclosure: I am the author. I also wrote [PhpMetrics](https://github.com/phpmetrics/PhpMetrics), already listed here; AST Metrics is its multi-language successor, and PhpMetrics remains maintained.

Contributing criteria:

- 147 stars
- 11 contributors
- First commit November 2023, actively released (latest: v0.40.2)

Only `data/tools/ast-metrics.yml` is added. `README.md` and `data/api/` are untouched. I ran `make render-skip-deprecated` locally to validate: it renders without error and the entry lands in the "Multiple languages" section.

Happy to adjust the wording, the tags or the category if you would rather have it described differently. Thanks for taking a look!
