### PR TITLE
Add REA to static analysis tools

### DIFF
--- a/data/tools/rea.yml
+++ b/data/tools/rea.yml
@@ -1,0 +1,20 @@
+name: REA
+categories:
+  - linter
+tags:
+  - binary
+  - dotnet
+  - javascript
+license: MIT
+types:
+  - cli
+source: 'https://github.com/morluto/rea'
+homepage: 'https://github.com/morluto/rea'
+description: >-
+  REA provides local CLI and MCP tools for agent-driven reverse engineering of
+  native binaries through Hopper and Ghidra, managed PE/CLI files,
+  JavaScript/Electron apps, and browser runtimes. It returns structured analysis
+  results with evidence for tracing application behavior.
+resources:
+  - title: Quick start
+    url: https://github.com/morluto/rea#quick-start


### PR DESCRIPTION
## Summary

- Add [REA](https://github.com/morluto/rea) to the static-analysis catalog.
- Classify it under binary, .NET, and JavaScript analysis.
- Describe its local CLI and MCP tools for agent-driven reverse engineering through Hopper and Ghidra.

REA has 168 GitHub stars, has been public since April 2026, and is actively maintained. The entry is a source-only addition under `data/tools/`; `README.md` remains generated and unchanged.

This PR was prepared with AI assistance.

## Validation

- `cargo run --manifest-path ci/Cargo.toml -p render -- --tags data/tags.yml --tools data/tools --md-out <temporary README> --json-out <temporary directory>`
- `git diff --check`
- The entry meets the repository's requirements for activity, maturity, and adoption.
