### PR TITLE
Add Wakaru

### DIFF
--- a/data/tools/wakaru.yml
+++ b/data/tools/wakaru.yml
@@ -1,0 +1,21 @@
+name: Wakaru
+categories:
+  - formatter
+tags:
+  - javascript
+  - typescript
+license: Apache License 2.0
+types:
+  - cli
+  - service
+source: "https://github.com/pionxzh/wakaru"
+homepage: "https://wakarujs.com"
+demos:
+  - "https://wakarujs.com/playground"
+description: >-
+  JavaScript decompiler that turns bundled, minified, transpiled production
+  code back into readable modules. Unpacks webpack, esbuild, Metro,
+  Browserify, SystemJS, and AMD/UMD bundles, then reverses minifier artifacts
+  and Babel/TypeScript/SWC helpers (async/await, classes, optional chaining,
+  and more). Written in Rust; runs as a CLI or fully in-browser via
+  WebAssembly.


### PR DESCRIPTION
Adds Wakaru, an open-source (Apache-2.0) JavaScript decompiler: it splits production bundles (webpack/esbuild/Metro/Browserify/…) back into modules and reverses minifier + transpiler output into readable code. Written in Rust, runs as a CLI and in-browser (WASM playground). 951 stars, actively maintained, multiple contributors. I'm the maintainer. `make render` passes locally; only the YAML is committed per convention.