### PR TITLE
Add peek — htop for codebases to Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,6 +953,8 @@ It uses the pycodestyle utility to determine what parts of the code needs to be 
 
 - [pyflakes](https://pypi.org/project/pyflakes) — Check Python source files for errors.
 
+- [peek](https://github.com/hariomlohardev/peek) — The htop for codebases — understand any repo in 5 seconds. Python + Rich + Textual TUI (`pip install peek-code && peek .`), import graph + PageRank `Start Here`, `peek --no-tui` for screenshots, `peek graph --format svg`.
+
 - [pylint](http://pylint.pycqa.org/en/latest) — Looks for programming errors, helps enforcing a coding standard and sniffs for some code smells. It additionally includes `pyreverse` (an UML diagram generator) and `symilar` (a similarities checker).
 
 - **pylyzers** :warning: — A static code analyzer / language server for Python, written in Rust, focused on type checking and readable output.


### PR DESCRIPTION
### What

Adds [peek](https://github.com/hariomlohardev/peek) — *the htop for codebases* — to **Python**.

- **One-liner:** `pip install peek-code && peek .` → 5 seconds to see languages, stack, `Start Here` ranked, and import graph
- **Stack:** Python + Rich + Textual TUI, `PageRank` + `ast` import graph, `peek --no-tui` for screenshots, `peek graph --format svg`, `peek --pack --ask` token-smart
- **Why it fits:** It’s a **static analysis / codebase intelligence** tool — like `ENRE-py` (entity relationship extractor) and `Griffe` (signatures for entire Python programs) but with a ranked `Start Here` and live TUI. Fits **Python** alongside `pyflakes`/`pylint`/`griffe`.

### Checklist

- [x] One-line description follows the list’s style (`Name — Description.`)
- [x] Link to GitHub repo
- [x] Fits **Python** (static analysis for codebases)
- [x] Actively maintained (146 tests, `peek-code` on PyPI, `v0.3.0`)

Thanks! :sparkles:

*Live at https://github.com/hariomlohardev/peek — demo `peek/assets/demo.gif` 800×450.*