### PR TITLE
Add skillsaw

### DIFF
--- a/data/tools/skillsaw.yml
+++ b/data/tools/skillsaw.yml
@@ -1,0 +1,19 @@
+name: skillsaw
+categories:
+  - linter
+tags:
+  - configfile
+  - json
+  - markdown
+  - security
+  - yaml
+license: Apache License 2.0
+types:
+  - cli
+source: 'https://github.com/stbenjam/skillsaw'
+homepage: 'https://skillsaw.org/'
+description: >-
+  Configurable linter for the files that steer AI coding agents, including
+  skills, plugins, instruction files, hooks, and related configuration. Detects
+  structural, content-quality, and security issues and provides deterministic
+  autofixes, baselines, and CI-ready output.


### PR DESCRIPTION
Adds skillsaw, a configurable linter for the files that steer AI coding agents.

Eligibility was verified against the contribution requirements: the project has 52 GitHub stars, 10 non-bot contributors, a history dating to October 2025, and current development activity. The YAML description is 269 characters.

This PR was created with AI assistance.

### 🛠️ Tool Requirements

- [x] I have not changed the `README.md` directly. (New tools go in `data/tools/`)
- [x] The tool has **more than 20 stars** on GitHub (or similar impact).
- [x] The project has existed for **at least 3 months**.
- [x] The project is **actively maintained**.
- [x] The description in the YAML file is **under 500 characters**.
