### PR TITLE
Add pyrift — static analyser for silent CPython/PyPy behaviour differences

### DIFF
--- a/data/tools/pyrift.yml
+++ b/data/tools/pyrift.yml
@@ -1,0 +1,22 @@
+name: pyrift
+categories:
+  - linter
+languages:
+  - python
+license: MIT
+types:
+  - cli
+source: https://github.com/BHUVANSH855/pyrift
+homepage: https://pypi.org/project/pyrift/
+description: >-
+  Detects silent Python behaviour differences across CPython versions and
+  between CPython and PyPy — patterns that linters, type checkers, and
+  security scanners all miss. Covers 90 rules including deprecated APIs,
+  removed stdlib modules, GC timing differences, and version-specific
+  runtime traps.
+tags:
+  - python
+  - compatibility
+  - linter
+  - cpython
+  - pypy


### PR DESCRIPTION
pyrift is a static analysis tool that detects silent Python behaviour 
differences across CPython versions and between CPython and PyPy.

These are patterns that linters, type checkers, and security scanners 
all miss — they only appear at runtime.

- 90 rules (45 CPython version compatibility + 45 PyPy runtime differences)
- 392 tests passing on Python 3.10, 3.11, 3.12, 3.13
- Zero dependencies — pure Python
- MIT licensed
- CLI + Python API + pre-commit hook support
- Baseline engine and target-aware scanning

GitHub: https://github.com/BHUVANSH855/pyrift
PyPI: https://pypi.org/project/pyrift/