### PR TITLE
Add Fallow

### DIFF
--- a/data/tools/fallow.yml
+++ b/data/tools/fallow.yml
@@ -20,7 +20,6 @@ resources:
   - title: Install via npm
     url: https://www.npmjs.com/package/fallow
 description: >-
-  Rust-native codebase intelligence for JavaScript and TypeScript. Finds unused files,
-  exports, types, and dependencies; circular dependencies; code duplication; complexity
-  hotspots; architecture boundary violations; and design-system styling drift. Ships as
-  a CLI, GitHub Action, VS Code extension, LSP, MCP server, and Node API.
+  Rust-native static analysis for JavaScript and TypeScript. Maps a repository as one
+  dependency graph to find unused code and structural problems across file boundaries.
+  Runs from the CLI or GitHub Actions, with VS Code, LSP, MCP, and Node API integrations.

--- a/data/tools/fallow.yml
+++ b/data/tools/fallow.yml
@@ -1,0 +1,26 @@
+name: Fallow
+categories:
+  - linter
+tags:
+  - javascript
+  - typescript
+  - jsx
+  - css
+  - nodejs
+  - ci
+license: MIT
+types:
+  - cli
+  - ide-plugin
+source: 'https://github.com/fallow-rs/fallow'
+homepage: 'https://fallow.tools'
+resources:
+  - title: Quickstart
+    url: https://docs.fallow.tools/quickstart
+  - title: Install via npm
+    url: https://www.npmjs.com/package/fallow
+description: >-
+  Rust-native codebase intelligence for JavaScript and TypeScript. Finds unused files,
+  exports, types, and dependencies; circular dependencies; code duplication; complexity
+  hotspots; architecture boundary violations; and design-system styling drift. Ships as
+  a CLI, GitHub Action, VS Code extension, LSP, MCP server, and Node API.


### PR DESCRIPTION
Adds Fallow, an MIT-licensed static analyzer and codebase intelligence tool for JavaScript and TypeScript.

The open-source static layer detects unused code and dependencies, circular dependencies, duplication, complexity hotspots, architecture boundary violations, and design-system styling drift. It is available as a CLI and VS Code extension, with CI, LSP, MCP, and Node API integrations.

Fallow meets the catalog requirements: more than 20 GitHub stars, multiple human contributors, active development, and more than three months of project history.

This supersedes #1814, which was closed automatically as stale without review. The entry is refreshed against the current catalog format.
