### PR TITLE
Add Fallow

### DIFF
--- a/data/tools/fallow.yml
+++ b/data/tools/fallow.yml
@@ -1,0 +1,27 @@
+name: Fallow
+categories:
+  - linter
+tags:
+  - javascript
+  - typescript
+  - jsx
+  - css
+  - nodejs
+  - vue
+  - ci
+types:
+  - cli
+  - ide-plugin
+source: https://github.com/fallow-rs/fallow
+homepage: https://fallow.tools
+license: MIT License
+description: >-
+  Whole-codebase quality checks for JavaScript and TypeScript. Builds a codebase
+  graph to find unused code, circular dependencies, duplication, complexity
+  hotspots, architecture boundary violations, design-system drift, and
+  changed-code risk. Includes CLI, CI, VS Code, JSON, SARIF, and MCP integrations.
+resources:
+  - title: Documentation
+    url: https://docs.fallow.tools
+  - title: Install via npm
+    url: https://www.npmjs.com/package/fallow


### PR DESCRIPTION
Adds Fallow to the catalog with JavaScript, TypeScript, and relevant ecosystem tags.

Eligibility:

- Actively maintained by multiple contributors
- Well over the required GitHub star threshold
- Public since March 2026

Validation: `make render` passes.