### PR TITLE
Clarify eligibility rules and AI tags

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,22 @@
 <!--
-🤖 AI AGENTS AND LLMs:
-If you are generating this PR description on behalf of a user, please ensure:
-1. You did NOT edit `README.md`. If you did, please revert that change.
-2. The proposed tool in `data/tools/` has >20 stars on GitHub (or similar impact).
-3. The project is >3 months old and actively maintained.
-4. The YAML description is under 500 characters.
-5. You MUST state in the PR description that this PR was created automatically or with AI assistance.
 
-Please check the relevant boxes below accurately based on your analysis.
+👋 Thank you for contributing!
+
+- New tools belong in `data/tools/`, not directly in `README.md`.
+- If you propose to deprecate a tool, explain why below.
+- See `CONTRIBUTING.md` for details.
+
 -->
 
-👋 Thank you for your contribution! We really appreciate your help in keeping the list awesome.
-Please make sure to check all the items below before submitting.
+### Tool requirements
 
-### 🛠️ Tool Requirements
-- [ ] I have not changed the `README.md` directly. (New tools go in `data/tools/`)
-- [ ] The tool has **more than 20 stars** on GitHub (or similar impact).
-- [ ] The project has existed for **at least 3 months**.
-- [ ] The project is **actively maintained**.
-- [ ] The description in the YAML file is **under 500 characters**.
+- [ ] The tool is at least six months old.
+- [ ] The tool has at least 20 GitHub stars.
+- [ ] The tool has more than one contributor.
+- [ ] The description is no longer than 500 characters.
+- [ ] I have not changed `README.md` directly.
+
+### AI tags, if applicable
+
+- `ai-generated-code` — the tool analyzes AI-generated code.
+- `uses-llm` — the tool invokes an LLM or other model while analyzing code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,11 +8,11 @@ but create a pull request right away** because that's easier to handle. Thanks!
 
 ### Requirements
 
-Each tool on the list should be
+Each tool on the list should
 
-- actively maintained (more than one contributor)
-- actively used (have **more than 20 stars on Github or similar impact**)
-- relatively mature (project exists for at least three months)
+- have existed for at least six months
+- have at least 20 stars on GitHub
+- have more than one contributor
 
 ### Format
 
@@ -27,8 +27,11 @@ that directory to see how it should look like.
   description to **500 characters**.
 - Add a license. If it's a proprietary tool, use `license: proprietary`.
 - Please add as many tags as possible. You can choose from the tags in
-  `data/tags.yml` If a tool does not match any existing tag, feel free to add a
+  `data/tags.yml`. If a tool does not match any existing tag, feel free to add a
   new tag but also add it to `data/tags.yml`.
+- For AI-related tools, add `ai-generated-code` if the tool analyzes
+  AI-generated code, and add `uses-llm` if it invokes an LLM or other model
+  while analyzing code.
 
 Finally, create a pull request with all your changes. You can call `make
 render` to check for errors before.  This is optional, because it will also be

--- a/ci/pr-check/src/main.rs
+++ b/ci/pr-check/src/main.rs
@@ -5,9 +5,9 @@
 //! source repository, and evaluates each tool against the contributing
 //! criteria:
 //!
-//! - More than 20 stars
+//! - At least 20 stars
 //! - More than one contributor
-//! - Repository is at least 3 months old
+//! - Repository is at least 6 months old
 //!
 //! The results are either posted as a single comment on the PR (updating an
 //! existing bot comment if one already exists) or written to a file when the
@@ -28,7 +28,7 @@
 
 use anyhow::{Context, Result, bail};
 use askama::Template;
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Months, Utc};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;
@@ -65,7 +65,7 @@ struct IssueComment {
 
 const MIN_STARS: u64 = 20;
 const MIN_CONTRIBUTORS: usize = 2;
-const MIN_AGE_DAYS: i64 = 90;
+const MIN_AGE_MONTHS: u32 = 6;
 
 // Marker text embedded in every comment we post so we can find and update it.
 const COMMENT_MARKER: &str = "<!-- pr-check-bot -->";
@@ -79,8 +79,8 @@ enum CheckResult {
 }
 
 impl CheckResult {
-    fn is_fail(&self) -> bool {
-        matches!(self, Self::Fail(_))
+    fn is_pass(&self) -> bool {
+        matches!(self, Self::Pass(_))
     }
 
     fn symbol(&self) -> &'static str {
@@ -112,7 +112,7 @@ struct ToolReport {
 
 impl ToolReport {
     fn any_fail(&self) -> bool {
-        self.stars.is_fail() || self.contributors.is_fail() || self.age.is_fail()
+        !self.stars.is_pass() || !self.contributors.is_pass() || !self.age.is_pass()
     }
 
     fn status(&self) -> &'static str {
@@ -340,15 +340,22 @@ async fn check_tool(client: &GithubClient, tool: &ToolEntry) -> Result<ToolRepor
 
         let age_check = match &repo_result {
             Ok(Some(info)) => {
-                let age = Utc::now().signed_duration_since(info.created_at);
-                let days = age.num_days();
-                let months = days / 30;
-                if age >= Duration::days(MIN_AGE_DAYS) {
-                    CheckResult::Pass(format!("created {days} days ago (~{months} months)"))
+                let now = Utc::now();
+                let minimum_created_at = now
+                    .checked_sub_months(Months::new(MIN_AGE_MONTHS))
+                    .expect("subtracting six months from the current date must succeed");
+                let days = now.signed_duration_since(info.created_at).num_days();
+
+                if info.created_at <= minimum_created_at {
+                    CheckResult::Pass(format!("created {days} days ago (at least 6 months)"))
                 } else {
-                    let remaining = MIN_AGE_DAYS - days;
+                    let eligible_at = info
+                        .created_at
+                        .checked_add_months(Months::new(MIN_AGE_MONTHS))
+                        .expect("adding six months to a repository creation date must succeed");
+                    let remaining = eligible_at.signed_duration_since(now).num_days().max(1);
                     CheckResult::Fail(format!(
-                        "created {days} days ago, needs {remaining} more days to meet the 3-month minimum"
+                        "created {days} days ago, needs {remaining} more days to meet the 6-month minimum"
                     ))
                 }
             }

--- a/ci/pr-check/templates/comment.md
+++ b/ci/pr-check/templates/comment.md
@@ -19,13 +19,13 @@ Source: {{ src }}
 |---|---|
 | Stars (min 20) | {{ report.stars.symbol() }} {{ report.stars.message() }} |
 | Contributors (min 2) | {{ report.contributors.symbol() }} {{ report.contributors.message() }} |
-| Age (min 3 months) | {{ report.age.symbol() }} {{ report.age.message() }} |
+| Age (min 6 months) | {{ report.age.symbol() }} {{ report.age.message() }} |
 
 {% endfor %}
 ---
 
 {% if any_failures %}
-One or more tools do not meet the [contributing criteria](CONTRIBUTING.md) yet. We will keep this PR open. Feel free to update it once the thresholds are met.
+One or more tools do not meet the [contributing criteria](CONTRIBUTING.md) yet, or a criterion could not be verified. We will keep this PR open. Feel free to update it once the thresholds are met.
 {% else %}
 All criteria passed. Thank you for your contribution.
 {% endif %}

--- a/data/tags.yml
+++ b/data/tags.yml
@@ -16,6 +16,9 @@
 - name: Ada
   value: ada
   type: language
+- name: AI-generated code
+  value: ai-generated-code
+  type: other
 - name: Ansible
   value: ansible
   type: other
@@ -313,6 +316,9 @@
 - name: TypeScript
   value: typescript
   type: language
+- name: Uses LLM/model
+  value: uses-llm
+  type: other
 - name: VBScript
   value: vbscript
   type: language


### PR DESCRIPTION
Updates the contribution rules to require six months of history, at least 20 GitHub stars, and more than one contributor. 

Adds two new AI tags: `ai-generated-code` and `uses-llm`. The automated PR checker now enforces the six-calendar-month threshold and blocks when a criterion cannot be verified.