### PR TITLE
Add thailint

### DIFF
--- a/data/tools/thailint.yml
+++ b/data/tools/thailint.yml
@@ -1,0 +1,24 @@
+name: thailint
+categories:
+  - linter
+tags:
+  - python
+  - typescript
+  - javascript
+  - rust
+  - yaml
+  - terraform
+  - shell
+  - ai-generated-code
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/be-wise-be-kind/thai-lint'
+homepage: 'https://thai-lint.readthedocs.io/'
+description: >-
+  Multi-language linter targeting anti-patterns that appear disproportionately
+  in AI-generated code: duplicated blocks across files, excessive nesting,
+  magic numbers, Single Responsibility violations, and linter suppressions
+  added without justification. Covers Python, TypeScript, JavaScript and Rust
+  from one configuration, ships a pre-commit hook per rule, and emits text,
+  JSON or SARIF for CI.


### PR DESCRIPTION
Adds [thailint](https://github.com/be-wise-be-kind/thai-lint), a multi-language linter for anti-patterns that show up disproportionately in AI-generated code.

Disclosure: I maintain it.

## Requirements

| Requirement | Status |
|---|---|
| Existed at least six months | 324 days — first release 2025-10-07 |
| At least 20 GitHub stars | 20 |
| More than one contributor | 7 |

## What it covers

Duplicated blocks across files, excessive nesting, magic numbers, Single Responsibility violations, and linter suppressions added without justification — the last two being the ones least covered by existing entries. Python, TypeScript, JavaScript and Rust from one configuration, with a pre-commit hook per rule and text/JSON/SARIF output.

Tagged `ai-generated-code` since that is the whole premise rather than an afterthought.

## Notes on the entry

I could not run `make render` locally — no Rust toolchain on this machine — so CI will be the first render. To reduce the chance of it failing on something avoidable I checked the file against your data by hand:

- Every tag validated against `data/tags.yml`: `python`, `typescript`, `javascript`, `rust`, `yaml`, `terraform`, `shell`, `ai-generated-code`. I dropped `docker`, `toml` and `hcl` from my first draft after finding they are not in your vocabulary rather than adding new tags for them.
- `categories: [linter]`, matching the value used by 710 of the existing entries.
- Key set compared against all 758 existing tool files — no invented keys, and all seven universally-present keys are set.
- Description is 394 characters against the 500 limit.

Happy to adjust the tags or trim the description if you would rather it read differently.