### PR TITLE
Recover nestjs-doctor submission

### DIFF
--- a/data/tools/nestjs-doctor.yml
+++ b/data/tools/nestjs-doctor.yml
@@ -1,0 +1,17 @@
+name: nestjs-doctor
+categories:
+  - linter
+tags:
+  - typescript
+  - javascript
+license: MIT License
+types:
+  - cli
+  - ide-plugin
+source: "https://github.com/RoloBits/nestjs-doctor"
+homepage: "https://github.com/RoloBits/nestjs-doctor"
+description: >-
+  Static analysis tool for NestJS applications. Detects anti-patterns across
+  security, performance, correctness, and architecture with 30+ built-in rules.
+  Outputs a 0-100 health score. Includes module graph visualization, endpoint
+  dependency graphs, and database schema analysis. CLI and VS Code extension.


### PR DESCRIPTION
Recreates the tool entry from #1799, which was closed automatically and can no longer be reopened because the contributor fork was deleted. Original submission and credit: @Franciscuo in #1799.\n\nVerified eligibility for `RoloBits/nestjs-doctor`: created 2026-02-18, 157 GitHub stars, and 4 human contributors. The recovered YAML renders successfully.