### PR TITLE
Add jscpd

### DIFF
--- a/data/tools/jscpd.yml
+++ b/data/tools/jscpd.yml
@@ -1,0 +1,38 @@
+name: jscpd
+categories:
+  - linter
+tags:
+  - c
+  - ci
+  - cpp
+  - csharp
+  - css
+  - go
+  - html
+  - java
+  - javascript
+  - json
+  - jsx
+  - kotlin
+  - markdown
+  - nodejs
+  - php
+  - python
+  - ruby
+  - rust
+  - scala
+  - swift
+  - typescript
+  - yaml
+license: MIT License
+types:
+  - cli
+source: 'https://github.com/kucherenko/jscpd'
+homepage: 'https://jscpd.dev'
+description: >-
+  Copy/paste detector for programming source code. Finds duplicated blocks in
+  200+ file formats — JavaScript, TypeScript, Python, Java, C#, C/C++, Go,
+  Rust, PHP, Ruby and more — using token-based detection. Supports
+  configurable thresholds and ignore patterns, git blame integration, and
+  reporters for console, HTML, JSON, Markdown, SARIF and badges. Runs via CLI,
+  in CI pipelines, or as a library; bundled by MegaLinter and Codacy.


### PR DESCRIPTION
Adds [jscpd](https://github.com/kucherenko/jscpd) — a copy/paste (duplicate code) detector supporting 200+ file formats, with token-based detection, configurable thresholds, and console/HTML/JSON/Markdown/SARIF/badge reporters.

Meets the listing requirements:
- Existed since 2013
- ~6k stars on GitHub
- Multiple contributors

It is already bundled as the copy-paste linter in MegaLinter and supported by Codacy, and the npm package sees ~10M downloads/month.

Disclosure: I am the author/maintainer of jscpd.