### PR TITLE
Use serde-saphyr for CI YAML parsing

### DIFF
--- a/ci/Cargo.lock
+++ b/ci/Cargo.lock
@@ -12,10 +12,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "askama"
@@ -233,6 +256,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_detect"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8f80099a98041a3d1622845c271458a2d73e688351bf3cb999266764b81d48"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,10 +294,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
+name = "encoding_rs"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+checksum = "7b5ef0006ac9ab233c38522f5ae99cae3625151de8f706cacee1cba4b8e2832a"
+dependencies = [
+ "cfg-if",
+ "core_detect",
+ "multiversion",
+ "multiversion_no_op",
+ "rustversion",
+ "scopeguard",
+ "simdutf8",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
+dependencies = [
+ "encoding_rs",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -358,10 +405,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
-name = "hashbrown"
-version = "0.17.1"
+name = "granit-parser"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "48aa83cc6ac4dc610adf5501a5392b4bcc543b2c1f24eaf77469a96e31ec9abe"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+]
 
 [[package]]
 name = "http"
@@ -591,16 +642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,12 +730,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "libyaml-rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
-
-[[package]]
 name = "litemap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +763,33 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "multiversion"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ca4bea16ffc3f443cf7d866912118196bfef4c6a1556ca00f9f9b00bb43f7c"
+dependencies = [
+ "multiversion-macros",
+]
+
+[[package]]
+name = "multiversion-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d416831a7317ef4b08bee00b69cbbb9c8763da7959a7026244d6266869f9c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "multiversion_no_op"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743fb55ba31b18fb1ecef6bdc9aa2743314978ac084044301a7eee33fb99a20d"
 
 [[package]]
 name = "num-traits"
@@ -793,8 +855,8 @@ dependencies = [
  "pico-args",
  "reqwest",
  "serde",
+ "serde-saphyr",
  "tokio",
- "yaml_serde",
 ]
 
 [[package]]
@@ -914,10 +976,10 @@ dependencies = [
  "pico-args",
  "reqwest",
  "serde",
+ "serde-saphyr",
  "serde_json",
  "slug",
  "tokio",
- "yaml_serde",
 ]
 
 [[package]]
@@ -1068,12 +1130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1090,6 +1146,12 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1128,6 +1190,20 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afb591f9cdb6223c88ba39269aff895620c7f0716dc42b705b5733d5c7c0823"
+dependencies = [
+ "annotate-snippets",
+ "encoding_rs_io",
+ "granit-parser",
+ "num-traits",
+ "serde_core",
+ "smallvec",
 ]
 
 [[package]]
@@ -1450,6 +1526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,19 +1839,6 @@ name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
-
-[[package]]
-name = "yaml_serde"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b729a08a9a6be689bbad3e2bf8015926db54b6622cc89c3a5f7dc174b9e918"
-dependencies = [
- "indexmap",
- "itoa",
- "libyaml-rs",
- "ryu",
- "serde",
-]
 
 [[package]]
 name = "yoke"

--- a/ci/Cargo.toml
+++ b/ci/Cargo.toml
@@ -16,5 +16,5 @@ pico-args = "0.5"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "system-proxy"] }
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
-serde_yaml = { package = "yaml_serde", version = "0.10.7" }
+serde-saphyr = { version = "1.2", default-features = false, features = ["deserialize"] }
 tokio = { version = "1.53.1", features = ["rt-multi-thread", "macros"] }

--- a/ci/pr-check/Cargo.toml
+++ b/ci/pr-check/Cargo.toml
@@ -38,6 +38,6 @@ askama = { workspace = true }
 chrono = { workspace = true }
 pico-args = { workspace = true }
 serde = { workspace = true }
-serde_yaml = { workspace = true }
+serde-saphyr = { workspace = true }
 tokio = { workspace = true }
 reqwest = { workspace = true }

--- a/ci/pr-check/src/main.rs
+++ b/ci/pr-check/src/main.rs
@@ -307,7 +307,7 @@ fn parse_github_repo(url: &str) -> Option<(String, String)> {
 /// Returns an error if the file cannot be read or parsed.
 fn read_tool(path: &Path) -> Result<ToolEntry> {
     let f = std::fs::File::open(path).with_context(|| format!("Cannot open {}", path.display()))?;
-    serde_yaml::from_reader(f).with_context(|| format!("Cannot parse {}", path.display()))
+    serde_saphyr::from_reader(f).with_context(|| format!("Cannot parse {}", path.display()))
 }
 
 /// Runs all contributing-criteria checks for one tool.
@@ -519,6 +519,22 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_catalog() -> Result<()> {
+        let tools = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../data/tools");
+        let mut count = 0;
+        for entry in std::fs::read_dir(tools)? {
+            let path = entry?.path();
+            if path.extension().is_some_and(|ext| ext == "yml") {
+                let tool = read_tool(&path)?;
+                assert!(!tool.name.is_empty(), "{}", path.display());
+                count += 1;
+            }
+        }
+        assert!(count > 0);
+        Ok(())
+    }
 
     #[test]
     fn parses_plain_github_url() {

--- a/ci/render/Cargo.toml
+++ b/ci/render/Cargo.toml
@@ -50,7 +50,7 @@ chrono = { workspace = true }
 pico-args = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
+serde-saphyr = { workspace = true }
 tokio = { workspace = true }
 askama = { workspace = true }
 reqwest = { workspace = true }

--- a/ci/render/src/bin/main.rs
+++ b/ci/render/src/bin/main.rs
@@ -27,7 +27,7 @@ fn parse_path(s: &OsStr) -> Result<PathBuf> {
 
 fn read_tags(path: PathBuf) -> Result<Tags> {
     let f = std::fs::File::open(path)?;
-    Ok(serde_yaml::from_reader(f)?)
+    Ok(serde_saphyr::from_reader(f)?)
 }
 
 fn read_tools(path: PathBuf) -> Result<Vec<ParsedEntry>> {
@@ -47,7 +47,7 @@ fn read_tools(path: PathBuf) -> Result<Vec<ParsedEntry>> {
         .inspect(|p| println!("Checking {}", p.display()))
         .map(|p| {
             let file = std::fs::File::open(p)?;
-            let entry: ParsedEntry = serde_yaml::from_reader(file)?;
+            let entry: ParsedEntry = serde_saphyr::from_reader(file)?;
             Ok(entry)
         })
         .collect::<Result<Vec<ParsedEntry>, _>>()
@@ -158,4 +158,22 @@ async fn main() -> Result<()> {
     // ))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_catalog() -> Result<()> {
+        let data = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../data");
+        let tags = read_tags(data.join("tags.yml"))?;
+        let tools = read_tools(data.join("tools"))?;
+        assert!(!tags.is_empty());
+        assert!(!tools.is_empty());
+        for tool in tools {
+            Entry::from_parsed(tool, &tags)?;
+        }
+        Ok(())
+    }
 }

--- a/data/tools/klee.yml
+++ b/data/tools/klee.yml
@@ -13,7 +13,7 @@ resources:
   - title: "Introduction to symbolic execution with KLEE"
     url: "https://www.youtube.com/watch?v=z6bsk-lsk1Q"
   - title: "KLEE: Unassisted and Automatic Generation of High-Coverage
-Tests for Complex Systems Programs [Original Paper]"
+      Tests for Complex Systems Programs [Original Paper]"
     url: "https://www.usenix.org/legacy/event/osdi08/tech/full_papers/cadar/cadar.pdf"
 description: >-
   A dynamic symbolic execution engine built on top of the LLVM compiler

--- a/data/tools/redex.yml
+++ b/data/tools/redex.yml
@@ -16,5 +16,5 @@ resources:
     url: https://www.youtube.com/watch?v=vtxJvJj6gSE
   - title: Optimizing Android bytecode with ReDex
     url: https://engineering.fb.com/android/optimizing-android-bytecode-with-redex/
-  - title:
+  - title: ""
     url: https://www.youtube.com/watch?v=h_Gkl5eAdc4


### PR DESCRIPTION
Follow up on #1852 by switching the CI tools from yaml_serde to serde-saphyr for typed YAML parsing without the libyaml backend. The original deprecation was already addressed in #1879; this adopts the alternative parser and fixes two YAML values its stricter parsing rejects, preserving the rendered content.